### PR TITLE
Fix Response POST requests

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -116,7 +116,7 @@ class User(AbstractBaseUser, PermissionsMixin, GuardianUserMixin):
 
     @property
     def latest_demographics(self):
-        return self.demographics.last()
+        return self.demographics.first()
 
     @property
     def identicon_small_html(self):

--- a/studies/serializers.py
+++ b/studies/serializers.py
@@ -81,7 +81,7 @@ class ResponseSerializer(UUIDSerializerMixin, ModelSerializer):
         many=False,
         related_link_view_name='demographicdata-detail',
         related_link_lookup_field='uuid',
-        required = False
+        required=False
     )
 
     class Meta:
@@ -98,3 +98,18 @@ class ResponseSerializer(UUIDSerializerMixin, ModelSerializer):
             'study',
             'demographic_snapshot',
         )
+
+
+class ResponseWriteableSerializer(ResponseSerializer):
+    def create(self, validated_data):
+        """
+        Use the ids for objects so django rest framework doesn't
+        try to create new objects out of spite
+        """
+        study = validated_data.pop('study')
+        validated_data['study_id'] = study.id
+        # implicitly set the demographic data because we know what it will be
+        validated_data['demographic_snapshot_id'] = validated_data.get('child').user.latest_demographics.id
+        child = validated_data.pop('child')
+        validated_data['child_id'] = child.id
+        return super().create(validated_data)


### PR DESCRIPTION
- Create Writeable serializer for Response objects
    - Use the ids instead of the actual objects so DRF doesn't try to create things.
- Swap in that serializer when creating responses
- Grab the latest demographic data off the specified child's user and use that id