### PR TITLE
Add proxy view, revproxy requirements, and default settings

### DIFF
--- a/project/settings/defaults.py
+++ b/project/settings/defaults.py
@@ -194,6 +194,9 @@ STATIC_URL = '/static/'
 
 STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 
+# base url for experiments, should be s3 bucket in prod
+EXPERIMENT_BASE_URL = os.environ.get('EXPERIMENT_BASE_URL', 'http://google.com/')  # default to ember base url
+
 LOGIN_REDIRECT_URL = os.environ.get('LOGIN_REDIRECT_URL', 'http://localhost:8000/')
 ACCOUNT_LOGOUT_REDIRECT_URL = os.environ.get('ACCOUNT_LOGOUT_REDIRECT_URL', '/api/')
 ACCOUNT_USER_MODEL_USERNAME_FIELD = 'id'

--- a/project/settings/local-dist.py
+++ b/project/settings/local-dist.py
@@ -1,1 +1,7 @@
+import os
+
 ALLOWED_HOSTS = ('*', )
+DEBUG = True
+
+# base url for experiments, should be s3 bucket in prod
+EXPERIMENT_BASE_URL = os.environ.get('EXPERIMENT_BASE_URL', 'http://localhost:4200')  # default to ember base url

--- a/project/urls.py
+++ b/project/urls.py
@@ -32,8 +32,8 @@ urlpatterns = [
     url(r'^admin/', admin.site.urls),
     url(r'^exp/', include(exp_urls, namespace='exp')),
     url(r'^api/', include(api_urls)),
-    url(r'^', include(web_urls, namespace='web')),
     url(r'^', include('django.contrib.auth.urls')),
+    url(r'^', include(web_urls, namespace='web')),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
 
 if settings.DEBUG:

--- a/requirements/defaults.txt
+++ b/requirements/defaults.txt
@@ -22,3 +22,4 @@ django-dynamic-fixture==1.9.5
 django-filter==1.0.2
 django-cors-headers==2.1.0
 pygraphviz==1.3.1
+django-revproxy==0.9.13

--- a/web/urls.py
+++ b/web/urls.py
@@ -15,7 +15,6 @@ urlpatterns = [
     url(r'^contact_us/?$', flatpages_views.flatpage, dict(url='/contact_us/'), name='contact_us'),
     url(r'^(?P<path>assets/.*)$', views.ExperimentAssetsProxyView.as_view(), name='experiment-assets-proxy'),
     url(r'^(?P<path>fonts/.*)$', views.ExperimentAssetsProxyView.as_view(), name='experiment-fonts-proxy'),
-    url(r'^(?P<path>ember-cli-live-reload\.js)$', views.ExperimentAssetsProxyView.as_view(), name='ember-cli-live-reload-proxy'),  # we shouldn't need this in prod
-    url(r'^(?P<path>VideoRecorder\.swf)$', views.ExperimentAssetsProxyView.as_view(), name='videorecorder-proxy'),
     url(r'^$', flatpages_views.flatpage, dict(url='/'), name='home'),
+    url(r'^(?P<path>.*)$', views.ExperimentAssetsProxyView.as_view(), name='experiment-catchall-proxy'),
 ]

--- a/web/urls.py
+++ b/web/urls.py
@@ -15,6 +15,7 @@ urlpatterns = [
     url(r'^contact_us/?$', flatpages_views.flatpage, dict(url='/contact_us/'), name='contact_us'),
     url(r'^(?P<path>assets/.*)$', views.ExperimentAssetsProxyView.as_view(), name='experiment-assets-proxy'),
     url(r'^(?P<path>fonts/.*)$', views.ExperimentAssetsProxyView.as_view(), name='experiment-fonts-proxy'),
-    url(r'^(?P<path>ember-cli-live-reload.js)$', views.ExperimentAssetsProxyView.as_view(), name='ember-cli-live-reload-proxy'),  # we shouldn't need this in prod
+    url(r'^(?P<path>ember-cli-live-reload\.js)$', views.ExperimentAssetsProxyView.as_view(), name='ember-cli-live-reload-proxy'),  # we shouldn't need this in prod
+    url(r'^(?P<path>VideoRecorder\.swf)$', views.ExperimentAssetsProxyView.as_view(), name='videorecorder-proxy'),
     url(r'^$', flatpages_views.flatpage, dict(url='/'), name='home'),
 ]

--- a/web/urls.py
+++ b/web/urls.py
@@ -13,5 +13,8 @@ urlpatterns = [
     url(r'^scientists/?$', flatpages_views.flatpage, dict(url='/scientists/'), name='scientists'),
     url(r'^resources/?$', flatpages_views.flatpage, dict(url='/resources/'), name='resources'),
     url(r'^contact_us/?$', flatpages_views.flatpage, dict(url='/contact_us/'), name='contact_us'),
+    url(r'^(?P<path>assets/.*)$', views.ExperimentAssetsProxyView.as_view(), name='experiment-assets-proxy'),
+    url(r'^(?P<path>fonts/.*)$', views.ExperimentAssetsProxyView.as_view(), name='experiment-fonts-proxy'),
+    url(r'^(?P<path>ember-cli-live-reload.js)$', views.ExperimentAssetsProxyView.as_view(), name='ember-cli-live-reload-proxy'),  # we shouldn't need this in prod
     url(r'^$', flatpages_views.flatpage, dict(url='/'), name='home'),
 ]

--- a/web/urls.py
+++ b/web/urls.py
@@ -8,6 +8,7 @@ urlpatterns = [
     url(r'^demographic_data/?$', views.DemographicDataCreateView.as_view(), name='demographic-data-create'),
     url(r'^studies/?$', views.StudiesListView.as_view(), name='studies-list'),
     url(r'^studies/(?P<uuid>[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89ab][0-9a-fA-F]{3}-[0-9a-fA-F]{12})/$', views.StudyDetailView.as_view(), name='study-detail'),
+    url(r'^studies/(?P<path>(?P<uuid>[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89ab][0-9a-fA-F]{3}-[0-9a-fA-F]{12})/(?P<child_id>[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89ab][0-9a-fA-F]{3}-[0-9a-fA-F]{12}))/?$', views.ExperimentProxyView.as_view(), name='experiment-proxy'),
     url(r'^faq/?$', flatpages_views.flatpage, dict(url='/faq/'), name='faq'),
     url(r'^scientists/?$', flatpages_views.flatpage, dict(url='/scientists/'), name='scientists'),
     url(r'^resources/?$', flatpages_views.flatpage, dict(url='/resources/'), name='resources'),

--- a/web/views.py
+++ b/web/views.py
@@ -104,6 +104,15 @@ class DemographicDataCreateView(generic.CreateView):
 
     def get_success_url(self):
         return reverse('web:studies-list')
+        
+
+class ExperimentAssetsProxyView(ProxyView):
+    upstream = settings.EXPERIMENT_BASE_URL
+
+    def dispatch(self, request, path, *args, **kwargs):
+        if request.user.is_anonymous:
+            raise PermissionDenied()
+        return super().dispatch(request, path)
 
 
 class ExperimentProxyView(ProxyView):

--- a/web/views.py
+++ b/web/views.py
@@ -4,11 +4,12 @@ from django.http import Http404
 from django.shortcuts import reverse
 from django.utils.translation import ugettext as _
 from django.views import generic
+from guardian.mixins import LoginRequiredMixin
+from revproxy.views import ProxyView
 
 from accounts import forms
 from accounts.models import Child, DemographicData, User
 from project import settings
-from revproxy.views import ProxyView
 from studies.models import Study
 
 
@@ -104,18 +105,13 @@ class DemographicDataCreateView(generic.CreateView):
 
     def get_success_url(self):
         return reverse('web:studies-list')
-        
 
-class ExperimentAssetsProxyView(ProxyView):
+
+class ExperimentAssetsProxyView(ProxyView, LoginRequiredMixin):
     upstream = settings.EXPERIMENT_BASE_URL
 
-    def dispatch(self, request, path, *args, **kwargs):
-        if request.user.is_anonymous:
-            raise PermissionDenied()
-        return super().dispatch(request, path)
 
-
-class ExperimentProxyView(ProxyView):
+class ExperimentProxyView(ProxyView, LoginRequiredMixin):
     upstream = settings.EXPERIMENT_BASE_URL
 
     def dispatch(self, request, path, *args, **kwargs):
@@ -124,7 +120,7 @@ class ExperimentProxyView(ProxyView):
         except Child.DoesNotExist:
             raise Http404()
 
-        if request.user.is_anonymous or child.user != request.user:
+        if child.user != request.user:
             # requesting user doesn't belong to that child
             raise PermissionDenied()
 


### PR DESCRIPTION
This creates a proxy view that uses `settings.EXPERIMENT_BASE_URL` and proxies  traffic going to /studies/<study_id>/<child_id>/ to `f'{settings.EXPERIMENT_BASE_URL}/studies/{study_id}/{child_id}/'`

Assuming EXPERIMENT_ BASE_URL = 'https://s3.bucket.tld/things/stuff/'

e.g.: https://staging2-lookit.osf.io/studies/uuid1/uuid2/ will proxy to https://s3.bucket.tld/things/stuff/studies/uuid1/uuid2/

It also looks up the child specified in the url by the child id and checks to see if the requesting user has that child associated with them. If the user is anonymous or the child doesn't belong to them they get a 403. If the child doesn't exist they get a 404.