### PR TITLE
[RFR] Add support for media and static file storage in le cloud

### DIFF
--- a/exp/templates/exp/base.html
+++ b/exp/templates/exp/base.html
@@ -1,4 +1,5 @@
 {% load bootstrap3 %}
+{% load static %}
 
 <!DOCTYPE html>
 <html lang="en">
@@ -14,11 +15,11 @@
     {% block head %}
         {% bootstrap_css %}
         {% bootstrap_javascript jquery=True %}
-        <link href="/static/exp/css/app.css" rel="stylesheet" />
+        <link href="{% static '/static/exp/css/app.css' %}" rel="stylesheet" />
         {% if request.user.is_superuser %}
         <style>
           body {
-              background: url('/static/exp/img/su-mode.svg') repeat transparent;
+              background: url('{% static '/static/exp/img/su-mode.svg' %}') repeat transparent;
               background-size: 400px 400px;
           }
         </style>

--- a/project/settings/defaults.py
+++ b/project/settings/defaults.py
@@ -53,6 +53,7 @@ INSTALLED_APPS = [
     'corsheaders',
     'rest_framework.authtoken',
     'rest_framework_json_api',
+    'storages',
 
     # our stuff
     'api',
@@ -190,10 +191,6 @@ SITE_ID = 1
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.9/howto/static-files/
 
-STATIC_URL = '/static/'
-
-STATIC_ROOT = os.path.join(BASE_DIR, 'static')
-
 # base url for experiments, should be s3 bucket in prod
 EXPERIMENT_BASE_URL = os.environ.get('EXPERIMENT_BASE_URL', 'http://google.com/')  # default to ember base url
 
@@ -226,9 +223,25 @@ SOCIALACCOUNT_PROVIDERS = \
         }
      }
 
-MEDIA_URL = '/media/'
-MEDIA_ROOT = os.path.join(BASE_DIR, 'media/')
 
 # Configuration for cross-site requests
-CORS_ORIGIN_ALLOW_ALL = True # Needs to be changed before production!
+CORS_ORIGIN_ALLOW_ALL = True  # Needs to be changed before production!
 CORS_ORIGIN_WHITELIST = ()
+
+if os.getenv('GOOGLE_APPLICATION_CREDENTIALS'):
+    STATICFILES_LOCATION = '/static'
+    STATICFILES_STORAGE = 'project.storages.LookitStaticStorage'
+    STATIC_URL = 'https://storage.googleapis.com/io-osf-lookit-staging2/static/'
+
+    MEDIAFILES_LOCATION = '/media'
+    DEFAULT_FILE_STORAGE = 'project.storages.LookitMediaStorage'
+    MEDIA_URL = 'https://storage.googleapis.com/io-osf-lookit-staging2/media/'
+
+    GS_BUCKET_NAME = 'io-osf-lookit-staging2'
+    GS_PROJECT_ID = 'cos-staging'
+else:
+    STATIC_URL = '/static/'
+    MEDIA_URL = '/media/'
+
+MEDIA_ROOT = os.path.join(BASE_DIR, 'media/')
+STATIC_ROOT = os.path.join(BASE_DIR, 'static')

--- a/project/settings/defaults.py
+++ b/project/settings/defaults.py
@@ -229,17 +229,19 @@ CORS_ORIGIN_ALLOW_ALL = True  # Needs to be changed before production!
 CORS_ORIGIN_WHITELIST = ()
 
 if os.getenv('GOOGLE_APPLICATION_CREDENTIALS'):
+    # if we're trying to use cloud storage
     STATICFILES_LOCATION = '/static'
     STATICFILES_STORAGE = 'project.storages.LookitStaticStorage'
-    STATIC_URL = 'https://storage.googleapis.com/io-osf-lookit-staging2/static/'
+    STATIC_URL = os.environ.get('STATIC_URL', 'https://storage.googleapis.com/io-osf-lookit-staging2/static/')
 
     MEDIAFILES_LOCATION = '/media'
     DEFAULT_FILE_STORAGE = 'project.storages.LookitMediaStorage'
-    MEDIA_URL = 'https://storage.googleapis.com/io-osf-lookit-staging2/media/'
+    MEDIA_URL = os.environ.get('MEDIA_URL', 'https://storage.googleapis.com/io-osf-lookit-staging2/media/')
 
-    GS_BUCKET_NAME = 'io-osf-lookit-staging2'
-    GS_PROJECT_ID = 'cos-staging'
+    GS_BUCKET_NAME = os.environ.get('GS_BUCKET_NAME', 'io-osf-lookit-staging2')
+    GS_PROJECT_ID = os.environ.get('GS_PROJECT_ID', 'cos-staging')
 else:
+    # we know nothing about cloud storage
     STATIC_URL = '/static/'
     MEDIA_URL = '/media/'
 

--- a/project/settings/local-dist.py
+++ b/project/settings/local-dist.py
@@ -2,6 +2,7 @@ import os
 
 ALLOWED_HOSTS = ('*', )
 DEBUG = True
+STATIC_URL = '/static/'
 
 # base url for experiments, should be s3 bucket in prod
 EXPERIMENT_BASE_URL = os.environ.get('EXPERIMENT_BASE_URL', 'http://localhost:4200')  # default to ember base url

--- a/project/storages.py
+++ b/project/storages.py
@@ -1,0 +1,21 @@
+from django.conf import settings
+
+from storages.backends.gcloud import GoogleCloudStorage
+from storages.utils import safe_join
+
+
+class LocationPrefixedGoogleCloudStorage(GoogleCloudStorage):
+    location = None
+
+    def _normalize_name(self, name):
+        if self.location:
+            return super()._normalize_name(safe_join(self.location, name.lower()))
+        return super()._normalize_name(name.lower())
+
+
+class LookitStaticStorage(LocationPrefixedGoogleCloudStorage):
+    location = settings.STATICFILES_LOCATION
+
+
+class LookitMediaStorage(LocationPrefixedGoogleCloudStorage):
+    location = settings.MEDIAFILES_LOCATION

--- a/project/urls.py
+++ b/project/urls.py
@@ -25,19 +25,18 @@ from exp import urls as exp_urls
 from project import settings
 from web import urls as web_urls
 
-favicon_view = RedirectView.as_view(url='/static/images/favicon.ico', permanent=True)
-
 urlpatterns = [
-    url(r'^favicon\.ico$', favicon_view),
     url(r'^admin/', admin.site.urls),
     url(r'^exp/', include(exp_urls, namespace='exp')),
     url(r'^api/', include(api_urls)),
     url(r'^', include('django.contrib.auth.urls')),
     url(r'^', include(web_urls, namespace='web')),
-] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
+]
 
 if settings.DEBUG:
+    favicon_view = RedirectView.as_view(url='/static/images/favicon.ico', permanent=True)
     import debug_toolbar
     urlpatterns = [
+        url(r'^favicon\.ico$', favicon_view),
         url(r'^__debug__/', include(debug_toolbar.urls)),
     ] + urlpatterns + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/requirements/defaults.txt
+++ b/requirements/defaults.txt
@@ -23,3 +23,4 @@ django-filter==1.0.2
 django-cors-headers==2.1.0
 pygraphviz==1.3.1
 django-revproxy==0.9.13
+-e git+https://github.com/jschneier/django-storages.git#egg=django-storages

--- a/studies/templates/studies/study_detail.html
+++ b/studies/templates/studies/study_detail.html
@@ -1,5 +1,6 @@
 {% extends 'exp/base.html' %}
 {% load bootstrap3 %}
+{% load static %}
 
 {% block title %}{{ study.name }}{% endblock %}
 {% block flash %}
@@ -92,7 +93,7 @@
                           <div class="input-group">
                             <input type="text" class="form-control" id="private-study-link" value="https://lookit.mit.edu/studies/{{study.uuid }}" aria-describedby="copy-link-button">
                             <span onmouseout="removeTooltip(this)" data-toggle="tooltip" class="input-group-addon btn" id="copy-link-button" data-clipboard-target="#private-study-link" >
-                                <img src="/static/exp/img/clippy.svg" width="13"/>
+                                <img src="{% static '/static/exp/img/clippy.svg' %}" width="13"/>
                             </span>
                           </div>
                       {% endif %}

--- a/web/migrations/0001_create_initial_flatpages.py
+++ b/web/migrations/0001_create_initial_flatpages.py
@@ -105,7 +105,7 @@ flatpages = [
     		<div class="footer-row lookit-row">
     			<div class="container">
     				<div class="row">
-    					<div class="col-md-1"><img src="/static/images/nsf.gif"></div>
+    					<div class="col-md-1"><img src="https://storage.googleapis.com/io-osf-lookit-staging2/static/images/nsf.gif"></div>
     					<div class="col-md-11">
     						This material is based upon work supported by the National Science Foundation (NSF) under Grant No. 1429216; the Center for Brains, Minds and Machines (CBMM), funded by NSF STC award CCF-1231216, and by an NSF Graduate Research Fellowship under Grant No. 1122374. Any opinion, findings, and conclusions or recommendations expressed in this material are those of the authors(s) and do not necessarily reflect the views of the National Science Foundation.
     					</div>
@@ -170,7 +170,7 @@ flatpages = [
     								<p>If we receive a consent form that does NOT clearly demonstrate informed consent--for instance, we see a parent and child but the parent does not read the statement--any other video collected during that session will be deleted without viewing.</p>
     								<div class="row">
     									<div class="col-sm-10 col-sm-offset-1 col-md-8 col-md-offset-2 col-lg-6 col-lg-offset-3">
-    										<video controls="true" src="/static/videos/consent.mp4"></video>
+    										<video controls="true" src="https://storage.googleapis.com/io-osf-lookit-staging2/static/videos/consent.mp4"></video>
     									</div>
     								</div>
     							</div>
@@ -220,13 +220,13 @@ flatpages = [
     								<p>For children under about two years old, we usually design our studies to let their eyes do the talking! We're interested in where on the screen your child looks and/or how long your child looks at the screen rather than looking away. Our calibration videos (example shown below) help us get an idea of what it looks like when your child is looking to the right or the left, so we can code the rest of the video.</p>
     								<div class="row">
     									<div class="col-sm-10 col-sm-offset-1 col-md-8 col-md-offset-2 col-lg-6 col-lg-offset-3">
-    										<video controls="true" src="/static/videos/attentiongrabber.mp4"></video>
+    										<video controls="true" src="https://storage.googleapis.com/io-osf-lookit-staging2/static/videos/attentiongrabber.mp4"></video>
     									</div>
     								</div>
     								<p>Here's an example of a few children watching our calibration video--it's easy to see that they look to one side and then the other.</p>
     								<div class="row">
     									<div class="col-sm-10 col-sm-offset-1 col-md-8 col-md-offset-2 col-lg-6 col-lg-offset-3">
-    										<video controls="true" src="/static/videos/spinningball.mp4"></video>
+    										<video controls="true" src="https://storage.googleapis.com/io-osf-lookit-staging2/static/videos/spinningball.mp4"></video>
     									</div>
     								</div>
     								<p>Your child's decisions about where to look can give us lots of information about what he or she understands. Here are some of the techniques our lab uses to learn more about how children learn.</p>
@@ -239,7 +239,7 @@ flatpages = [
     								<p>Even when they seem to be passive observers, children are making lots of decisions about where to look and what to pay attention to. In this technique, we present children with a choice between two side-by-side images or videos, and see if children spend more time looking at one of them. We may additionally play audio that matches one of the videos. The video below shows a participant looking to her left when asked to "find clapping"; the display she's watching is shown at the top.</p>
     								<div class="row">
     									<div class="col-sm-10 col-sm-offset-1 col-md-8 col-md-offset-2 col-lg-6 col-lg-offset-3">
-    										<video controls="true" src="/static/videos/clapping.mp4"></video>
+    										<video controls="true" src="https://storage.googleapis.com/io-osf-lookit-staging2/static/videos/clapping.mp4"></video>
     									</div>
     								</div>
     								<h4>Predictive looking</h4>
@@ -248,7 +248,7 @@ flatpages = [
     								<p>Older children may simply be able to answer spoken questions about what they think is happening. For instance, in the "Learning from Others" study we ran last year, two women call an object two different made-up names, and children are asked which is the correct name for the object.</p>
     								<div class="row">
     									<div class="col-sm-10 col-sm-offset-1 col-md-8 col-md-offset-2 col-lg-6 col-lg-offset-3">
-    										<video controls="true" src="/static/videos/causal_ex2.mp4"></video>
+    										<video controls="true" src="https://storage.googleapis.com/io-osf-lookit-staging2/static/videos/causal_ex2.mp4"></video>
     									</div>
     								</div>
     								<p>Another way we can learn about how older children (and adults) think is to measure their reaction times. For instance, we might ask you to help your child learn to press one key when a circle appears and another key when a square appears, and then look at factors that influence how quickly they press a key.</p>
@@ -449,21 +449,21 @@ flatpages = [
     		<div class="container">
     			<div class="row">
     				<div class="lookit-scientist col-sm-6 col-md-4 col-lg-3">
-    					<div class="profile-img"><img src="/static/images/kimandremy.png"></div>
+    					<div class="profile-img"><img src="https://storage.googleapis.com/io-osf-lookit-staging2/static/images/kimandremy.png"></div>
     					<h3>Kim Scott</h3>
     					<p>Kim is a graduate student in the Early Childhood Cognition Lab and Mama to six-year-old Remy. She developed Lookit partly to enable other single parents to participate in research!</p>
     					<p>Research interests: Origins of conscious experience--or what it's like to be a baby</p>
     					<p>Hobbies: Board games, aerial silks, bicycling</p>
     				</div>
     				<div class="lookit-scientist col-sm-6 col-md-4 col-lg-3">
-    					<div class="profile-img"><img src="/static/images/laura.JPG"></div>
+    					<div class="profile-img"><img src="https://storage.googleapis.com/io-osf-lookit-staging2/static/images/laura.JPG"></div>
     					<h3>Laura Schulz</h3>
     					<p>Laura is the PI of the Early Childhood Cognition Lab.</p>
     					<p>Research interests: How children arrive at a common-sense understanding of the physical and social world through exploration and instruction.</p>
     					<p>Hobbies: hiking, reading, and playing</p>
     				</div>
     				<div class="lookit-scientist col-sm-6 col-md-4 col-lg-3">
-    					<div class="profile-img"><img src="/static/images/molly.jpg"></div>
+    					<div class="profile-img"><img src="https://storage.googleapis.com/io-osf-lookit-staging2/static/images/molly.jpg"></div>
     					<h3>Molly Dillon</h3>
     					<p>Molly is a graduate student in the Lab for Developmental Studies at Harvard. She’ll be starting her own lab in July 2017 as an Assistant Professor at NYU. Molly explores the origins of abstract thought, especially in the domains of geometry and number.</p>
     					<p>Hobbies: ballet, tennis, speaking French</p>
@@ -473,74 +473,74 @@ flatpages = [
     				<h3>Alumni &amp; Collaborators</h3>
     				<hr>
     				<div class="lookit-scientist col-sm-6 col-md-4 col-lg-3">
-    					<div class="profile-img"><img src="/static/images/jessica.jpg"></div>
+    					<div class="profile-img"><img src="https://storage.googleapis.com/io-osf-lookit-staging2/static/images/jessica.jpg"></div>
     					<h3>Jessica Zhu</h3>
     					<p>Undergraduate, MIT</p>
     					<p>Hobbies: Playing cards, eating watermelon, and hanging out with friends</p>
     				</div>
     				<div class="lookit-scientist col-sm-6 col-md-4 col-lg-3">
-    					<div class="profile-img"><img src="/static/images/audrey.jpg"></div>
+    					<div class="profile-img"><img src="https://storage.googleapis.com/io-osf-lookit-staging2/static/images/audrey.jpg"></div>
     					<h3>Audrey Ricks (Summer 2016)</h3>
     					<p>Undergraduate, MIT</p>
     					<p>Hobbies: Biking, learning and exploring</p>
     				</div>
     				<div class="lookit-scientist col-sm-6 col-md-4 col-lg-3">
-    					<div class="profile-img"><img src="/static/images/hope.jpg"></div>
+    					<div class="profile-img"><img src="https://storage.googleapis.com/io-osf-lookit-staging2/static/images/hope.jpg"></div>
     					<h3>Hope Fuller-Becker (Sp 2015, Sp 2016)</h3>
     					<p>Undergraduate, Wellesley College</p>
     					<p>Hobbies: drawing, painting, reading and running</p>
     				</div>
     				<div class="lookit-scientist col-sm-6 col-md-4 col-lg-3">
-    					<div class="profile-img"><img src="/static/images/rianna.jpg"></div>
+    					<div class="profile-img"><img src="https://storage.googleapis.com/io-osf-lookit-staging2/static/images/rianna.jpg"></div>
     					<h3>Rianna Shah (IAP, Sp, Fall 2015; IAP, Sp 2016)</h3>
     					<p>Undergraduate, MIT</p>
     					<p>Hobbies: Singing, playing the piano, and karate!</p>
     				</div>
     				<div class="lookit-scientist col-sm-6 col-md-4 col-lg-3">
-    					<div class="profile-img"><img src="/static/images/junyi.jpg"></div>
+    					<div class="profile-img"><img src="https://storage.googleapis.com/io-osf-lookit-staging2/static/images/junyi.jpg"></div>
     					<h3>Junyi Chu (Summer 2015)</h3>
     					<p>Recent graduate, Vanderbilt University</p>
     					<p>Hobbies: Rock climbing, board and card games</p>
     				</div>
     				<div class="lookit-scientist col-sm-6 col-md-4 col-lg-3">
-    					<div class="profile-img"><img src="/static/images/joseph.jpg"></div>
+    					<div class="profile-img"><img src="https://storage.googleapis.com/io-osf-lookit-staging2/static/images/joseph.jpg"></div>
     					<h3>Joseph Alvarez (Summer 2015)</h3>
     					<p>Undergraduate, Skidmore College</p>
     					<p>Hobbies: Creating, discovering, and playing electric guitar!</p>
     				</div>
     				<div class="lookit-scientist col-sm-6 col-md-4 col-lg-3">
-    					<div class="profile-img"><img src="/static/images/annie.jpg"></div>
+    					<div class="profile-img"><img src="https://storage.googleapis.com/io-osf-lookit-staging2/static/images/annie.jpg"></div>
     					<h3>Annie Dai (IAP, Sp 2015)</h3>
     					<p>Undergraduate, MIT</p>
     					<p>Hobbies: Running, spending time outdoors, listening to music</p>
     				</div>
     				<div class="lookit-scientist col-sm-6 col-md-4 col-lg-3">
-    					<div class="profile-img"><img src="/static/images/jeanyu.jpg"></div>
+    					<div class="profile-img"><img src="https://storage.googleapis.com/io-osf-lookit-staging2/static/images/jeanyu.jpg"></div>
     					<h3>Jean Yu (IAP, Sp 2015)</h3>
     					<p>Undergraduate, Wellesley College</p>
     					<p>Hobbies: ballet, figure skating, piano, making art, learning about art, reading about art, learning about the brain</p>
     				</div>
     				<div class="lookit-scientist col-sm-6 col-md-4 col-lg-3">
-    					<div class="profile-img"><img src="/static/images/daniela.jpg"></div>
+    					<div class="profile-img"><img src="https://storage.googleapis.com/io-osf-lookit-staging2/static/images/daniela.jpg"></div>
     					<h3>Daniela Carrasco (Sp 2015)</h3>
     					<p>Undergraduate, MIT</p>
     					<p>Hobbies: Crossfit athlete, swimming, boxing, painting and sketching</p>
     				</div>
     				<div class="lookit-scientist col-sm-6 col-md-4 col-lg-3">
-    					<div class="profile-img"><img src="/static/images/jean.jpg"></div>
+    					<div class="profile-img"><img src="https://storage.googleapis.com/io-osf-lookit-staging2/static/images/jean.jpg"></div>
     					<h3>Jean Chow (Fa 2014)</h3>
     					<p>Undergraduate, MIT</p>
     					<p>Research interests: cognitive development and learning in young children</p>
     					<p>Hobbies: Running, cycling, Taekwondo, art, being outdoors, chilling with her dog</p>
     				</div>
     				<div class="lookit-scientist col-sm-6 col-md-4 col-lg-3">
-    					<div class="profile-img"><img src="/static/images/melissa.png"></div>
+    					<div class="profile-img"><img src="https://storage.googleapis.com/io-osf-lookit-staging2/static/images/melissa.png"></div>
     					<h3>Melissa Kline</h3>
     					<p>As a graduate student in the Early Childhood Cognition Lab, Melissa advised and designed stimuli for the "Learning New Verbs" study.</p>
     					<p>Hobbies: Sewing, tango, and singing.</p>
     				</div>
     				<div class="lookit-scientist col-sm-6 col-md-4 col-lg-3">
-    					<div class="profile-img"><img src="/static/images/rachel.png"></div>
+    					<div class="profile-img"><img src="https://storage.googleapis.com/io-osf-lookit-staging2/static/images/rachel.png"></div>
     					<h3>Rachel Magid</h3>
     					<p>Rachel is now a graduate student at ECCL; in her two years as our lab coordinator she helped get Lookit off the ground!</p>
     					<p>Hobbies: Reading historical fiction and cooking</p>
@@ -648,7 +648,7 @@ flatpages = [
     				<p><strong>What you'll need</strong>: At least ten small objects your child can pick up, like pegs or Cheerios</p>
     				<p><strong>A guided, online "give N" task is coming soon to Lookit!</strong></p>
     				<h4>Let your baby choose: understanding your infant's preferences</h4>
-    				<p><img src="/static/images/pacifier.png"></p>
+    				<p><img src="https://storage.googleapis.com/io-osf-lookit-staging2/static/images/pacifier.png"></p>
     				<p><strong>Age range</strong>: 0 to 6 months</p>
     				<p><strong>What you'll need</strong>: A pacifier that your infant will suck on for about 15 minutes at a time and the operant conditioning web tool.</p>
     				<p>In this lab, you'll let your baby control what sound is played by sucking faster or slower on a pacifier. We recommend starting by trying to observe his or her preference for hearing music or a heartbeat. <a href="http://www.mit.edu/~kimscott/instructions.html">Instructions</a></p>

--- a/web/static/base.css
+++ b/web/static/base.css
@@ -32,7 +32,7 @@ body {
 /* JUMBOTRON */
 .home-jumbotron {
     border-bottom: 1px solid #eee;
-    background:#351306 url('static/images/lookit_collage.jpg') center top no-repeat;
+    background:#351306 url('images/lookit_collage.jpg') center top no-repeat;
 }
 
 .home-jumbotron .content  {

--- a/web/static/base.css
+++ b/web/static/base.css
@@ -32,7 +32,7 @@ body {
 /* JUMBOTRON */
 .home-jumbotron {
     border-bottom: 1px solid #eee;
-    background:#351306 url('images/lookit_collage.jpg') center top no-repeat;
+    background:#351306 url('static/images/lookit_collage.jpg') center top no-repeat;
 }
 
 .home-jumbotron .content  {

--- a/web/templates/flatpages/default.html
+++ b/web/templates/flatpages/default.html
@@ -1,4 +1,5 @@
 {% load bootstrap3 %}
+{% load static %}
 
 <!DOCTYPE html>
 <html lang="en">
@@ -14,7 +15,7 @@
     {% bootstrap_javascript jquery=True %}
     <link href="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/css/select2.min.css" rel="stylesheet" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/js/select2.full.min.js"></script>
-    <link type="text/css" rel="stylesheet" href="/static/base.css" />
+    <link type="text/css" rel="stylesheet" href="{% static "/static/base.css" %}" />
   </head>
   <body>
     <div class="container-fluid">

--- a/web/templates/web/base.html
+++ b/web/templates/web/base.html
@@ -1,5 +1,5 @@
 {% load bootstrap3 %}
-
+{% load static %}
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -7,18 +7,20 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>{% block title %}{% endblock %} &mdash; Lookit</title>
     <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet">
-    <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+    <link rel="shortcut icon" type="image/x-icon" href="{% static "/static/images/favicon.ico" %}">
+
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no, maximum-scale=1">
     <meta name="apple-touch-fullscreen" content="yes">
     {% bootstrap_css %}
     {% bootstrap_javascript jquery=True %}
-    <link type="text/css" rel="stylesheet" href="/static/base.css" />
+    <link type="text/css" rel="stylesheet" href="{% static "/static/base.css" %}" />
     {% block head %}
     {% endblock %}
     <script src="https://use.fontawesome.com/41c082d3c2.js"></script>
   </head>
   <body>
+
     <div class="container-fluid">
       {% bootstrap_messages %}
       <header class="row">


### PR DESCRIPTION
- Add django storage package
- Update static file urls in flatpages
- Update static urls in templates to use static template tag
- Create custom storage engines for media and static files with prefixes
- Update css image path to include prefix
- Update settings to allow for environmental settings for django
storages

### Known issues
- The migration is going to be wrong on prod and local, only correct on staging
- The django-storages should be upgraded on the next release and pinned at 1.6.4, no date set yet
- Local dev will request some static files from staging's GCE storage because flat pages can't use the static template tag without a significant amount of work.
- STATIC_URL should probably pull from an env var.
