### PR TITLE
Feature/API Queryset/Permissions Cleanup

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 
 from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
 from guardian.shortcuts import get_objects_for_user
 from accounts.models import Child, DemographicData, Organization, User
 from accounts.serializers import (ChildSerializer, DemographicDataSerializer,
@@ -39,6 +40,7 @@ class OrganizationViewSet(FilterByUrlKwargsMixin, views.ModelViewSet):
     serializer_class = OrganizationSerializer
     filter_fields = [('study', 'study'), ('user', 'user'), ]
     http_method_names = [u'get', u'head', u'options']
+    permission_classes = [IsAuthenticated]
 
 
 class ChildViewSet(FilterByUrlKwargsMixin, views.ModelViewSet):
@@ -48,6 +50,7 @@ class ChildViewSet(FilterByUrlKwargsMixin, views.ModelViewSet):
     lookup_field = 'uuid'
     filter_fields = [('user', 'user'), ]
     http_method_names = [u'get', u'head', u'options']
+    permission_classes = [IsAuthenticated]
 
 
 class DemographicDataViewSet(FilterByUrlKwargsMixin, views.ModelViewSet):
@@ -57,6 +60,7 @@ class DemographicDataViewSet(FilterByUrlKwargsMixin, views.ModelViewSet):
     serializer_class = DemographicDataSerializer
     filter_fields = [('user', 'user'), ]
     http_method_names = [u'get', u'head', u'options']
+    permission_classes = [IsAuthenticated]
 
 
 class UserViewSet(FilterByUrlKwargsMixin, views.ModelViewSet):
@@ -66,6 +70,7 @@ class UserViewSet(FilterByUrlKwargsMixin, views.ModelViewSet):
     serializer_class = UserSerializer
     filter_fields = [('child', 'children'), ('response', 'responses'), ]
     http_method_names = [u'get', u'head', u'options']
+    permission_classes = [IsAuthenticated]
 
 
 class StudyViewSet(FilterByUrlKwargsMixin, views.ModelViewSet):
@@ -75,14 +80,15 @@ class StudyViewSet(FilterByUrlKwargsMixin, views.ModelViewSet):
     lookup_field = 'uuid'
     filter_fields = [('response', 'responses'), ]
     http_method_names = [u'get', u'head', u'options']
+    permission_classes = [IsAuthenticated]
 
     def get_queryset(self):
         """
-        Shows studies that are either 1) active and public or 2) studies you have permission to view.
+        Shows studies that are either 1) active and public or 2) studies you have permission to edit.
 
-        "can_view_study" permissions allows the researcher to preview the study before it has been made active/public
+        "can_edit_study" permissions allows the researcher to preview the study before it has been made active/public
         """
-        return (super().get_queryset() | get_objects_for_user(self.request.user, 'studies.can_view_study')).distinct()
+        return (super().get_queryset() | get_objects_for_user(self.request.user, 'studies.can_edit_study')).distinct()
 
 class ResponseFilter(filters.FilterSet):
     child = filters.UUIDFilter(name='child__uuid')
@@ -101,6 +107,7 @@ class ResponseViewSet(FilterByUrlKwargsMixin, views.ModelViewSet):
     filter_backends = (filters.DjangoFilterBackend,)
     filter_class = ResponseFilter
     http_method_names = [u'get', u'post', u'put', u'patch', u'head', u'options']
+    permission_classes = [IsAuthenticated]
 
     def get_serializer_class(self):
         """Return a different serializer for create views"""

--- a/api/views.py
+++ b/api/views.py
@@ -61,7 +61,7 @@ class ChildViewSet(FilterByUrlKwargsMixin, views.ModelViewSet):
 
         Show children that have 1) responded to studies you can view and 2) are your own children
         """
-        studies = get_objects_for_user(self.request.user, 'studies.can_view_study')
+        studies = get_objects_for_user(self.request.user, 'studies.can_view_study_responses')
         study_ids = studies.values_list('id', flat=True)
         return Child.objects.filter(Q(response__study__id__in=study_ids) | Q(user__id=self.request.user.id)).distinct()
 
@@ -82,7 +82,7 @@ class DemographicDataViewSet(FilterByUrlKwargsMixin, views.ModelViewSet):
 
         Shows 1) demographics attached to responses you can view, and 2) your own demographics
         """
-        studies = get_objects_for_user(self.request.user, 'studies.can_view_study')
+        studies = get_objects_for_user(self.request.user, 'studies.can_view_study_responses')
         study_ids = studies.values_list('id', flat=True)
         return DemographicData.objects.filter(Q(response__study__id__in=study_ids) | Q(user__id=self.request.user.id)).distinct()
 
@@ -104,7 +104,7 @@ class UserViewSet(FilterByUrlKwargsMixin, views.ModelViewSet):
         Shows 1) users that have responded to studies you can view and 2) your own user object
         """
         # TODO should we further restrict on participants only?
-        studies = get_objects_for_user(self.request.user, 'studies.can_view_study')
+        studies = get_objects_for_user(self.request.user, 'studies.can_view_study_responses')
         study_ids = studies.values_list('id', flat=True)
         return User.objects.filter(Q(children__response__study__id__in=study_ids) | Q(id=self.request.user.id)).distinct()
 
@@ -152,6 +152,8 @@ class ResponseViewSet(FilterByUrlKwargsMixin, views.ModelViewSet):
 
     def get_queryset(self):
         """
+        Overrides queryset.
+
         Shows responses that you either have permission to view, or responses by your own children
         """
         studies = get_objects_for_user(self.request.user, 'studies.can_view_study_responses')

--- a/api/views.py
+++ b/api/views.py
@@ -38,6 +38,7 @@ class OrganizationViewSet(FilterByUrlKwargsMixin, views.ModelViewSet):
     queryset = Organization.objects.all()
     serializer_class = OrganizationSerializer
     filter_fields = [('study', 'study'), ('user', 'user'), ]
+    http_method_names = [u'get', u'head', u'options']
 
 
 class ChildViewSet(FilterByUrlKwargsMixin, views.ModelViewSet):
@@ -46,6 +47,7 @@ class ChildViewSet(FilterByUrlKwargsMixin, views.ModelViewSet):
     serializer_class = ChildSerializer
     lookup_field = 'uuid'
     filter_fields = [('user', 'user'), ]
+    http_method_names = [u'get', u'head', u'options']
 
 
 class DemographicDataViewSet(FilterByUrlKwargsMixin, views.ModelViewSet):
@@ -54,6 +56,7 @@ class DemographicDataViewSet(FilterByUrlKwargsMixin, views.ModelViewSet):
     queryset = DemographicData.objects.filter(user__is_active=True)
     serializer_class = DemographicDataSerializer
     filter_fields = [('user', 'user'), ]
+    http_method_names = [u'get', u'head', u'options']
 
 
 class UserViewSet(FilterByUrlKwargsMixin, views.ModelViewSet):
@@ -62,6 +65,7 @@ class UserViewSet(FilterByUrlKwargsMixin, views.ModelViewSet):
     queryset = User.objects.filter(demographics__isnull=False).distinct()
     serializer_class = UserSerializer
     filter_fields = [('child', 'children'), ('response', 'responses'), ]
+    http_method_names = [u'get', u'head', u'options']
 
 
 class StudyViewSet(FilterByUrlKwargsMixin, views.ModelViewSet):
@@ -70,6 +74,7 @@ class StudyViewSet(FilterByUrlKwargsMixin, views.ModelViewSet):
     serializer_class = StudySerializer
     lookup_field = 'uuid'
     filter_fields = [('response', 'responses'), ]
+    http_method_names = [u'get', u'head', u'options']
 
 
 class ResponseFilter(filters.FilterSet):
@@ -88,6 +93,7 @@ class ResponseViewSet(FilterByUrlKwargsMixin, views.ModelViewSet):
     filter_fields = [('study', 'study'), ]
     filter_backends = (filters.DjangoFilterBackend,)
     filter_class = ResponseFilter
+    http_method_names = [u'get', u'post', u'put', u'patch', u'head', u'options']
 
     def get_serializer_class(self):
         """Return a different serializer for create views"""

--- a/api/views.py
+++ b/api/views.py
@@ -37,12 +37,10 @@ class FilterByUrlKwargsMixin(views.ModelViewSet):
 class OrganizationViewSet(FilterByUrlKwargsMixin, views.ModelViewSet):
     resource_name = 'organizations'
     lookup_field = 'uuid'
-    # TODO - maybe we should restrict more, but I think it's fine to show
-    # all orgs to everyone through the API
     queryset = Organization.objects.all()
     serializer_class = OrganizationSerializer
     filter_fields = [('study', 'study'), ('user', 'user'), ]
-    http_method_names = [u'get', u'head', u'options']
+    http_method_names = ['get', 'head', 'options']
     permission_classes = [IsAuthenticated]
 
 
@@ -52,7 +50,7 @@ class ChildViewSet(FilterByUrlKwargsMixin, views.ModelViewSet):
     serializer_class = ChildSerializer
     lookup_field = 'uuid'
     filter_fields = [('user', 'user'), ]
-    http_method_names = [u'get', u'head', u'options']
+    http_method_names = ['get', 'head', 'options']
     permission_classes = [IsAuthenticated]
 
     def get_queryset(self):
@@ -73,7 +71,7 @@ class DemographicDataViewSet(FilterByUrlKwargsMixin, views.ModelViewSet):
     queryset = DemographicData.objects.filter(user__is_active=True)
     serializer_class = DemographicDataSerializer
     filter_fields = [('user', 'user'), ]
-    http_method_names = [u'get', u'head', u'options']
+    http_method_names = ['get', 'head', 'options']
     permission_classes = [IsAuthenticated]
 
     def get_queryset(self):
@@ -94,7 +92,7 @@ class UserViewSet(FilterByUrlKwargsMixin, views.ModelViewSet):
     queryset = User.objects.filter(demographics__isnull=False).distinct()
     serializer_class = UserSerializer
     filter_fields = [('child', 'children'), ('response', 'responses'), ]
-    http_method_names = [u'get', u'head', u'options']
+    http_method_names = ['get', 'head', 'options']
     permission_classes = [IsAuthenticated]
 
     def get_queryset(self):
@@ -114,7 +112,7 @@ class StudyViewSet(FilterByUrlKwargsMixin, views.ModelViewSet):
     serializer_class = StudySerializer
     lookup_field = 'uuid'
     filter_fields = [('response', 'responses'), ]
-    http_method_names = [u'get', u'head', u'options']
+    http_method_names = ['get', 'head', 'options']
     permission_classes = [IsAuthenticated]
 
     def get_queryset(self):
@@ -141,7 +139,7 @@ class ResponseViewSet(FilterByUrlKwargsMixin, views.ModelViewSet):
     filter_fields = [('study', 'study'), ]
     filter_backends = (filters.DjangoFilterBackend,)
     filter_class = ResponseFilter
-    http_method_names = [u'get', u'post', u'put', u'patch', u'head', u'options']
+    http_method_names = ['get', 'post', 'put', 'patch', 'head', 'options']
     permission_classes = [IsAuthenticated]
 
     def get_serializer_class(self):

--- a/api/views.py
+++ b/api/views.py
@@ -117,11 +117,16 @@ class StudyViewSet(FilterByUrlKwargsMixin, views.ModelViewSet):
 
     def get_queryset(self):
         """
-        Shows studies that are either 1) active and public or 2) studies you have permission to edit.
+        Shows studies that are either 1) active or 2) studies you have permission to edit.
 
         "can_edit_study" permissions allows the researcher to preview the study before it has been made active/public
         """
-        return (super().get_queryset() | get_objects_for_user(self.request.user, 'studies.can_edit_study')).distinct()
+        qs = super().get_queryset()
+        # List View restricted to public.  Detail view can show a private or public study.
+        if 'List' in self.get_view_name():
+            qs = qs.filter(public=True)
+
+        return (qs | get_objects_for_user(self.request.user, 'studies.can_edit_study')).distinct()
 
 class ResponseFilter(filters.FilterSet):
     child = filters.UUIDFilter(name='child__uuid')

--- a/api/views.py
+++ b/api/views.py
@@ -110,7 +110,7 @@ class UserViewSet(FilterByUrlKwargsMixin, views.ModelViewSet):
 
 class StudyViewSet(FilterByUrlKwargsMixin, views.ModelViewSet):
     resource_name = 'studies'
-    queryset = Study.objects.filter(state='active', public=True)
+    queryset = Study.objects.filter(state='active')
     serializer_class = StudySerializer
     lookup_field = 'uuid'
     filter_fields = [('response', 'responses'), ]

--- a/studies/templates/studies/_study_status.html
+++ b/studies/templates/studies/_study_status.html
@@ -22,14 +22,17 @@
     });
     function statusSelected(status) {
         var commentsBlock = document.getElementById("rejectionComments");
+        var labelBlock = document.getElementsByClassName('comments-block')[0];
         if (status.value === 'reject' && "{{ study_perms }}".indexOf('can_approve_study') !== -1) {
             rejectionComments.disabled = false;
             rejectionComments.classList.remove("comments-text");
+            labelBlock.classList.remove("comments-label")
 
         } else {
             rejectionComments.disabled = true;
             rejectionComments.className += " comments-text";
             rejectionComments.value = "{{ study.comments }}";
+            labelBlock.className += " comments-label"
         }
     }
 </script>
@@ -55,7 +58,7 @@
                           </select>
                         </div>
                         <div class="pt-md">
-                            <label class="comments-block {% if study.state != 'rejected' %}comments-label{% endif %}"> Comments: </label>
+                            <label class="comments-block"> Comments: </label>
                             {% get_obj_perms request.user for study as "study_perms" %}
                             <em><textarea id="rejectionComments" class="comments-text rejection-comments" name="comments-text" disabled rows="4" cols="34">{{study.comments}}</textarea></em>
                         </div>

--- a/studies/templates/studies/_study_status.html
+++ b/studies/templates/studies/_study_status.html
@@ -58,7 +58,7 @@
                           </select>
                         </div>
                         <div class="pt-md">
-                            <label class="comments-block"> Comments: </label>
+                            <label class="comments-block comments-label"> Comments: </label>
                             {% get_obj_perms request.user for study as "study_perms" %}
                             <em><textarea id="rejectionComments" class="comments-text rejection-comments" name="comments-text" disabled rows="4" cols="34">{{study.comments}}</textarea></em>
                         </div>

--- a/studies/templates/studies/study_detail.html
+++ b/studies/templates/studies/study_detail.html
@@ -101,7 +101,7 @@
                       </p>
                   </div>
                   <div class="col-xs-12 col-sm-4">
-                      {% if not study.public %}
+                      {% if not study.public and study.state == 'active' %}
                           <div class="input-group">
                             <input type="text" class="form-control" id="private-study-link" value="{% url 'web:study-detail' study.uuid %}" aria-describedby="copy-link-button">
                             <span onmouseout="removeTooltip(this)" data-toggle="tooltip" class="input-group-addon btn" id="copy-link-button" data-clipboard-target="#private-study-link" >


### PR DESCRIPTION
# Purpose

Audit API endpoints, making sure that data is properly restricted.  API may be accessed by both participants (who are taking the study) and researchers (who are previewing a study).  This is why a lot of the querysets are either 1) items attached to studies you have permission to view or 2) your own items

- [x] Restrict all endpoints to GET/OPTIONS methods only except for Responses which gets GET/POST/PUT/PATCH/DELETE/OPTIONS.  
- [x] Enforce need to be authenticated on all api views
- [x] Studies are either active, public. studies or studies you have permission to edit (so researchers can preview studies).  Study Detail view will allow private studies, so you can get a private, view-only link.
- [x] Organizations - show all
- [x] Responses -shows responses you have permission to view or your own responses.
- [x] Children - show children attached to studies whose responses you can view or your own children
- [x] Users - show users attached to studies whose responses you can view or your own user object
- [x] demographic data - show demographic data attached to responses you can view or your own demographic versions
