### PR TITLE
Feature/Send Confirmation Emails and Password Reset Emails to Researchers

### DIFF
--- a/accounts/templates/accounts/researcher_detail.html
+++ b/accounts/templates/accounts/researcher_detail.html
@@ -69,8 +69,10 @@
     <div class="row">
       <div class="col-xs-12">
           <div class="pull-right researcher-emails ">
-              <button class="btn btn-default password-button"> Send password reset email </button>
-              <button class="btn btn-default password-button"> Resend confirmation email </button>
+              <form method="post">{% csrf_token %}
+                  <button type="submit" name="reset_password" class="btn btn-default password-button"> Send password reset email </button>
+                  <button type="submit" name="resend_confirmation" class="btn btn-default password-button"> Resend confirmation email </button>
+              </form>
           </div>
       </div>
     </div>

--- a/accounts/templates/accounts/researcher_detail.html
+++ b/accounts/templates/accounts/researcher_detail.html
@@ -3,7 +3,6 @@
 
 {% block title %}{{ user.get_full_name }}{% endblock %}
 {% block flash %}
-  {% bootstrap_messages %}
   {% if form.non_field_errors %}
   <div class="alert alert-danger" role="alert">
       {{ form.non_field_errors }}
@@ -16,6 +15,7 @@
     $(document).ready(function() {
         $('#given_name').editable({
             success: function(response, newValue) {
+                 $('.alert-success').hide()
                  $('#researcher-details').show();
                  $('#researcher-edit').hide();
                  $('#researcher-first')[0].innerHTML = newValue;
@@ -23,6 +23,7 @@
         });
         $('#middle_name').editable({
             success: function(response, newValue) {
+                 $('.alert-success').hide()
                  $('#researcher-details').show();
                  $('#researcher-edit').hide();
 
@@ -30,6 +31,7 @@
         });
         $('#family_name').editable({
             success: function(response, newValue) {
+                 $('.alert-success').hide()
                  $('#researcher-details').show();
                  $('#researcher-edit').hide();
                  $('#researcher-last')[0].innerHTML = newValue;
@@ -42,6 +44,7 @@
                   {value: 'org_admin', text: 'Organization Admin'}
               ],
               success: function(response, newValue) {
+                   $('.alert-success').hide()
                    $('#researcher-details').hide();
                    $('#no-org-explanation').hide();
                    $('#researcher-edit').show();
@@ -51,6 +54,7 @@
 </script>
 <div class="container mb-lg">
     <div class="row">
+        {% bootstrap_messages %}
         <div id="researcher-edit" class="alert alert-success alert-dismissable" style="display:none;">
             <a href="#" class="close" onclick="$('.alert').hide()">&times;</a>
             <div> Researcher permissions saved. </div>

--- a/accounts/templates/emails/resend_confirmation.html
+++ b/accounts/templates/emails/resend_confirmation.html
@@ -1,0 +1,13 @@
+<p>
+  Dear {{ researcher_name }},
+</p>
+<p>
+    Here is a link to verify your email address on the OSF: {{ osf_url}}/resend/.
+</p>
+<p>
+    After verification, use your OSF credentials to login to Experimenter: {{ base_url }}{{ login_url }}.
+</p>
+<p>
+    Best,
+    <div> {{ org_name }} Admin </div>
+</p>

--- a/accounts/templates/emails/resend_confirmation.txt
+++ b/accounts/templates/emails/resend_confirmation.txt
@@ -1,0 +1,8 @@
+Dear {{ researcher_name }},
+
+Here is a link to verify your email address on the OSF: {{ osf_url}}/resend/.
+
+After verification, use your OSF credentials to login to Experimenter: {{ base_url }}{{ login_url }}.
+
+Best,
+{{ org_name }} Admin

--- a/accounts/templates/emails/reset_password.html
+++ b/accounts/templates/emails/reset_password.html
@@ -1,0 +1,13 @@
+<p>
+  Dear {{ researcher_name }},
+</p>
+<p>
+    Here is a link to reset your password on the OSF: {{ osf_url}}/forgotpassword/.
+</p>
+<p>
+    After resetting your password, use those credentials to login to Experimenter: {{ base_url }}{{ login_url }}.
+</p>
+<p>
+    Best,
+    <div> {{ org_name }} Admin </div>
+</p>

--- a/accounts/templates/emails/reset_password.txt
+++ b/accounts/templates/emails/reset_password.txt
@@ -1,0 +1,8 @@
+Dear {{ researcher_name }},
+
+Here is a link to reset your password on the OSF: {{ osf_url }}/forgotpassword/.
+
+After resetting your password, use those credentials to login to Experimenter: {{ base_url }}{{ login_url }}.
+
+Best,
+{{ org_name }} Admin

--- a/exp/views/user.py
+++ b/exp/views/user.py
@@ -225,9 +225,9 @@ class ResearcherDetailView(ExperimenterLoginRequiredMixin, DjangoPermissionRequi
             'org_name': self.request.user.organization.name,
             'login_url': login_url
         }
-        subject = 'Resend OSF confirmation email to login to Experimenter'
+        subject = 'Confirm OSF account to login to Experimenter'
         send_mail.delay('resend_confirmation', subject, self.object.username, **context)
-        messages.success(self.request, f'Resend confirmation email to {self.object.username}.')
+        messages.success(self.request, f'Confirmation email resent to {self.object.username}.')
         return
 
     def post(self, request, *args, **kwargs):

--- a/exp/views/user.py
+++ b/exp/views/user.py
@@ -236,18 +236,24 @@ class ResearcherDetailView(ExperimenterLoginRequiredMixin, DjangoPermissionRequi
         user permissions
         """
         retval = super().post(request, *args, **kwargs)
-        changed_field = self.request.POST.get('name')
-        if changed_field == 'given_name':
-            self.object.given_name = self.request.POST['value']
-        elif changed_field == 'middle_name':
-            self.object.middle_name = self.request.POST['value']
-        elif changed_field == 'family_name':
-            self.object.family_name = self.request.POST['value']
+
+        if 'reset_password' in self.request.POST:
+            self.send_reset_password_email()
+        elif 'resend_confirmation' in self.request.POST:
+            self.send_resend_confirmation_email()
+        else:
+            changed_field = self.request.POST.get('name')
+            if changed_field == 'given_name':
+                self.object.given_name = self.request.POST['value']
+            elif changed_field == 'middle_name':
+                self.object.middle_name = self.request.POST['value']
+            elif changed_field == 'family_name':
+                self.object.family_name = self.request.POST['value']
+            if not self.object.organization:
+                self.object.organization = request.user.organization
+            if self.request.POST.get('name') == 'user_permissions':
+                self.modify_researcher_permissions()
         self.object.is_active = True
-        if not self.object.organization:
-            self.object.organization = request.user.organization
-        if self.request.POST.get('name') == 'user_permissions':
-            self.modify_researcher_permissions()
         self.object.save()
         return retval
 

--- a/studies/helpers.py
+++ b/studies/helpers.py
@@ -1,7 +1,7 @@
 from django.core.mail.message import EmailMultiAlternatives
 from django.template.loader import get_template
 from project.celery import app
-from project.settings import EMAIL_FROM_ADDRESS, BASE_URL
+from project.settings import EMAIL_FROM_ADDRESS, BASE_URL, OSF_URL
 
 
 @app.task
@@ -19,6 +19,7 @@ def send_mail(template_name, subject, to_addresses, cc=None, bcc=None, from_emai
     :kwargs: Context vars for the email template
     """
     context['base_url'] = BASE_URL
+    context['osf_url'] = OSF_URL
 
     text_content = get_template('emails/{}.txt'.format(template_name)).render(context)
     html_content = get_template('emails/{}.html'.format(template_name)).render(context)


### PR DESCRIPTION
# Purpose

Connect these buttons on the Researcher Detail page.
<img width="401" alt="screen shot 2017-08-29 at 1 03 04 pm" src="https://user-images.githubusercontent.com/9755598/29847301-94a306e8-8ce0-11e7-83d8-d914be58cb9d.png">

# Changes
Enable sending reset password and confirmation emails to researcher through celery.  Really a two-step process.  Sends an email to researcher that gives them the OSF link that will enable them to reset password/resend confirmation email. Not ideal but not sure what else to do.

# QA
Test researcher detail page again

# Note
Reset password page for participants working ok. 