### PR TITLE
Feature/Remove comments in approval emails [LEI-462]

### DIFF
--- a/studies/templates/emails/notify_researchers_of_approval_decision.html
+++ b/studies/templates/emails/notify_researchers_of_approval_decision.html
@@ -3,7 +3,6 @@
 </p>
 <p>
   Your study {{ study_name }} has been{% if approved %} approved {% else %} disapproved {% endif %}to run on {{ org_name }}.
-  Comments from the Organization Admin, if there are any, appear below.
 </p>
 <p>
   {% if approved %}
@@ -14,7 +13,7 @@
   <br>
   Your study can be found <a href="{{base_url}}{% url 'exp:study-detail' pk=study_id %}">here</a>.
 </p>
-{% if comments %}
+{% if comments and not approved %}
   <p>
   Comments from the Organization Admin:
   <br>

--- a/studies/templates/emails/notify_researchers_of_approval_decision.txt
+++ b/studies/templates/emails/notify_researchers_of_approval_decision.txt
@@ -1,7 +1,6 @@
 Dear Study Admin,
 
 Your study {{study_name}} has been {% if approved %}approved{% else %}disapproved{% endif %} to run on {{ org_name }}.
-Comments from the Organization Admin, if there are any, appear below.
 
 {% if approved %}
 To start your study, login to Experimenter, navigate to the study, and select "Activate" from the dropdown.
@@ -10,11 +9,10 @@ You can modify your study and resubmit for approval.
 {% endif %}
 Your study can be found here: {{base_url}}{% url 'exp:study-detail' study_id %}
 
-{% if comments %}
+{% if comments and not approved  %}
 Comments from the Organization Admin:
 
 {{comments}}
-
 {% endif %}
 Best,
 {{ org_name }} Admin


### PR DESCRIPTION
# Ticket
https://openscience.atlassian.net/browse/LEI-462

# Purpose
remove references to comments in approval emails, as the admin has no ability to even leave comments when approving.
also, its currently showing the "rejection" comments in the template for approvals, which is confusing.