### PR TITLE
Feature/Display UUID's Experimenter-Side, more documentation

### DIFF
--- a/accounts/templates/accounts/participant_detail.html
+++ b/accounts/templates/accounts/participant_detail.html
@@ -21,6 +21,7 @@
           <div class="col-xs-12">
               <h1> {{ user.identicon_html }} {% if user.nickname %} {{ user.nickname }}{% else %} Participant ID {{ user.id }} {% endif %}</h1>
               <span><label class='pr-xs'> Last Active: </label> {{ user.last_login|date:"n/d/Y"|default:"N/A" }} </span>
+              <div><label class='pr-xs'> Participant UUID: </label> {{ user.uuid }} </div>
           </div>
       </div>
 

--- a/docs/source/django-project-installation.md
+++ b/docs/source/django-project-installation.md
@@ -1,0 +1,24 @@
+# Django Project Installation
+
+This is the codebase for Experimenter and Lookit.  Experimenter is a platform for designing and administering research studies, meant for researchers. The Lookit platform is participant-facing, where users can signup and take part in studies. It is built using Django, PostgreSQL, and Ember.js (see Ember portion of codebase, [ ember-lookit-frameplayer](https://github.com/CenterForOpenScience/ember-lookit-frameplayer)), and is developed by the [Center for Open Science](https://cos.io/).
+
+### Prerequisites
+- Make sure you have python 3.6: `$ python --version`.  If you don't have this, install from https://www.python.org/.
+- Make sure you have `pip`. `$ pip --version`
+- Create a virtual environment with python 3.6
+  - One way to do this:
+  - `$  pip install virtualenv`
+  - `$ virtualenv -p python3 envname`, *where `envname` is the name of your virtual environment.*
+  - `$ source envname/bin/activate` *Activates your virtual environment*
+- Install postgres
+  - make sure you have brew `$ brew`
+  - `$ brew install postgresql`
+  - `$ brew services start postgres` *Starts up postgres*
+  - `$ createdb lookit` *Creates lookit database*
+
+### Installation
+- `$ git clone https://github.com/CenterForOpenScience/lookit-api.git`
+- `$ cd lookit-api`
+- `$ sh up.sh` *Installs dependencies and run migrations*
+- `$ python manage.py createsuperuser` *Creates superuser locally (has all user permissions)*
+- `$ python manage.py runserver` *Starts up server*

--- a/docs/source/ember-app-installation.md
+++ b/docs/source/ember-app-installation.md
@@ -32,10 +32,6 @@ Before beginning, you will need to install Yarn, a package manager (like npm).
  bower install
 ```
 
-To use the video capture facilities of Lookit, you will also need to place the file `VideoRecorder.swf`
-in your `ember-lookit-frameplayer/public/` folder. **This file is not part of the git repository**; it is from the HDFVR flash video
-recorder and must be obtained from a team member with access to the licensed version.
-
 Create or open a file named '.env' in the root of the ember-lookit-frameplayer directory, and add the following entries:
 
 ```
@@ -43,6 +39,10 @@ WOWZA_PHP='{"minRecordTime":1,"showMenu":"false","showTimer":"false","enableBlin
 WOWZA_ASP='{"showMenu":"false","loopbackMic":"true","skipInitialScreen":1,"showSoundBar":"true","snapshotEnable":"false"}'
 ```
 A more complete configuration string is available upon request. In this application, we typically use WOWZA_PHP for settings in which a video is actually recorded, and WOWZA_ASP for video preview screens where no video is to be saved. The value of connectionstring is available internally but not committed to Github; it must be replaced with a reference to the streaming server. Other settings are as described in the sample avc_settings.php file provided in the HDFVR installation zip file.
+
+## Video Recording
+If you are using this ember app in conjunction with [lookit-api](https://github.com/CenterForOpenScience/lookit-api), the video recording functionality is taken care of in that repo. If you are not using lookit-api, and wish to use the video capture facilities of Lookit, you will need to place the file `VideoRecorder.swf`
+in your `ember-lookit-frameplayer/public/` folder.  This file can be found in the [ember-build](https://github.com/CenterForOpenScience/lookit-api/tree/develop/ember_build) directory of lookit-api.
 
 ## Running / Development
 

--- a/docs/source/ember-app-installation.md
+++ b/docs/source/ember-app-installation.md
@@ -1,0 +1,64 @@
+# Ember App Installation
+
+This is a small Ember application that allows both researchers to preview an experiment and users to
+participate in an experiment. This is meant to be used in conjunction with the [Lookit API Django project](https://github.com/CenterForOpenScience/lookit-api), which contains the Experimenter and Lookit applications.
+The Django applications will proxy to these Ember routes for previewing/participating in an experiment.
+The Ember routes will fetch the appropriate models and then pass them to the exp-player component in [exp-addons](https://github.com/CenterForOpenScience/exp-addons).
+
+## Prerequisites
+
+You will need the following things properly installed on your computer.
+
+* [Git](http://git-scm.com/)
+* [Node.js](http://nodejs.org/) (with NPM)
+* [Bower](http://bower.io/)
+* [Ember CLI](http://ember-cli.com/)
+* [PhantomJS](http://phantomjs.org/)
+
+## Installation
+
+Before beginning, you will need to install Yarn, a package manager (like npm).
+
+```bash
+ git clone https://github.com/CenterForOpenScience/ember-lookit-frameplayer.git
+ cd ember-lookit-frameplayer
+ git submodule init
+ git submodule update
+ yarn install --pure-lockfile
+ bower install
+
+ cd lib/exp-player
+ yarn install --pure-lockfile
+ bower install
+```
+
+To use the video capture facilities of Lookit, you will also need to place the file `VideoRecorder.swf`
+in your `ember-lookit-frameplayer/public/` folder. **This file is not part of the git repository**; it is from the HDFVR flash video
+recorder and must be obtained from a team member with access to the licensed version.
+
+Create or open a file named '.env' in the root of the ember-lookit-frameplayer directory, and add the following entries:
+
+```
+WOWZA_PHP='{"minRecordTime":1,"showMenu":"false","showTimer":"false","enableBlinkingRec":1,"skipInitialScreen":1,"recordAgain":"false","showSoundBar":"true","hideDeviceSettingsButtons":1,"microphoneGain": 60,"connectionstring":"CONNECTIONSTRING"}'
+WOWZA_ASP='{"showMenu":"false","loopbackMic":"true","skipInitialScreen":1,"showSoundBar":"true","snapshotEnable":"false"}'
+```
+A more complete configuration string is available upon request. In this application, we typically use WOWZA_PHP for settings in which a video is actually recorded, and WOWZA_ASP for video preview screens where no video is to be saved. The value of connectionstring is available internally but not committed to Github; it must be replaced with a reference to the streaming server. Other settings are as described in the sample avc_settings.php file provided in the HDFVR installation zip file.
+
+## Running / Development
+
+* `ember serve`
+* Visit your app at [http://localhost:4200](http://localhost:4200).
+
+### Code Generators
+
+Make use of the many generators for code, try `ember help generate` for more details
+
+### Running Tests
+
+* `ember test`
+* `ember test --server`
+
+### Building
+
+* `ember build` (development)
+* `ember build --environment production` (production)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -18,3 +18,5 @@ Contents:
 
    definitions
    api-documentation
+   django-project-installation
+   ember-app-installation

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,7 +8,7 @@ Welcome to lookit-api's documentation!
 
 **NOTE: This documentation is a work in progress**
 
-The lookit-api codebase contains the Experimenter and Lookit applications.  Experimenter is a platform for designing and administering research studies, meant for researchers. The Lookit platform is participant-facing, where users can signup and take part in studies.
+The `lookit-api codebase <https://github.com/CenterForOpenScience/lookit-api>`_ contains the Experimenter and Lookit applications.  Experimenter is a platform for designing and administering research studies, meant for researchers. The Lookit platform is participant-facing, where users can signup and take part in studies.
 It is built using Django, PostgreSQL, and Ember.js (see Ember portion of codebase, `ember-lookit-frameplayer <https://github.com/CenterForOpenScience/ember-lookit-frameplayer>`_), and is developed by the `Center for Open Science <https://cos.io/>`_.
 
 Contents:

--- a/exp/mixins/study_responses_mixin.py
+++ b/exp/mixins/study_responses_mixin.py
@@ -30,14 +30,17 @@ class StudyResponsesMixin(ExperimenterLoginRequiredMixin, PermissionRequiredMixi
             latest_dem = resp.demographic_snapshot
             json_responses.append(json.dumps({
                 "response": {
-                    'id': resp.id
+                    'id': resp.id,
+                    'uuid': str(resp.uuid),
                 },
                 "participant": {
                     'id': resp.child.user_id,
+                    'uuid': str(resp.child.user.uuid),
                     'nickname': resp.child.user.nickname
                 },
                 "demographic_snapshot": {
                     "demographic_id": latest_dem.id,
+                    "uuid": str(latest_dem.uuid),
                     "number_of_children": latest_dem.number_of_children,
                     "child_birthdays": latest_dem.child_birthdays,
                     "languages_spoken_at_home": latest_dem.languages_spoken_at_home,
@@ -65,7 +68,7 @@ class StudyResponsesMixin(ExperimenterLoginRequiredMixin, PermissionRequiredMixi
         """
         latest_dem = resp.demographic_snapshot
 
-        return [resp.id, resp.child.user_id, resp.child.user.nickname, latest_dem.id,
+        return [resp.id, str(resp.uuid), resp.child.user_id, str(resp.child.user.uuid), resp.child.user.nickname, latest_dem.id, str(latest_dem.uuid),
             latest_dem.number_of_children, [self.convert_to_string(birthday) for birthday in latest_dem.child_birthdays],
             latest_dem.languages_spoken_at_home, latest_dem.number_of_guardians, latest_dem.number_of_guardians_explanation,
             latest_dem.race_identification, latest_dem.age, latest_dem.gender, latest_dem.education_level, latest_dem.spouse_education_level,
@@ -76,7 +79,7 @@ class StudyResponsesMixin(ExperimenterLoginRequiredMixin, PermissionRequiredMixi
         """
         Returns header row for csv participant data
         """
-        return ['response_id', 'participant_id', 'participant_nickname', 'demographic_id',
+        return ['response_id', 'response_uuid', 'participant_id', 'participant_uuid', 'participant_nickname', 'demographic_id', 'latest_dem_uuid',
         'demographic_number_of_children', 'demographic_child_birthdays', 'demographic_languages_spoken_at_home',
         'demographic_number_of_guardians', 'demographic_number_of_guardians_explanation',
         'demographic_race_identification', 'demographic_age', 'demographic_gender',
@@ -94,6 +97,7 @@ class StudyResponsesMixin(ExperimenterLoginRequiredMixin, PermissionRequiredMixi
             json_responses.append(json.dumps({
                 'response': {
                     'id': resp.id,
+                    'uuid': str(resp.uuid),
                     'sequence': resp.sequence,
                     'conditions': resp.conditions,
                     'exp_data': resp.exp_data,
@@ -101,14 +105,17 @@ class StudyResponsesMixin(ExperimenterLoginRequiredMixin, PermissionRequiredMixi
                     'completed': resp.completed,
                 },
                 'study': {
-                    'id': resp.study.id
+                    'id': resp.study.id,
+                    'uuid': str(resp.study.uuid),
                 },
                 'participant': {
                     'id': resp.child.user_id,
+                    'uuid': str(resp.child.user.uuid),
                     'nickname': resp.child.user.nickname
                 },
                 'child': {
                     'id': resp.child.id,
+                    'uuid': str(resp.child.uuid),
                     'name': resp.child.given_name,
                     'birthday': resp.child.birthday,
                     'gender': resp.child.gender,
@@ -125,8 +132,8 @@ class StudyResponsesMixin(ExperimenterLoginRequiredMixin, PermissionRequiredMixi
         """
         Builds individual row for csv responses
         """
-        return [resp.id, resp.sequence, resp.conditions, resp.exp_data, resp.global_event_timings, resp.completed, resp.study.id,
-            resp.child.user_id, resp.child.user.nickname, resp.child.id, resp.child.given_name, resp.child.birthday, resp.child.gender,
+        return [resp.id, str(resp.uuid), resp.sequence, resp.conditions, resp.exp_data, resp.global_event_timings, resp.completed, resp.study.id, str(resp.study.uuid),
+            resp.child.user_id, str(resp.child.user.uuid), resp.child.user.nickname, resp.child.id, str(resp.child.uuid), resp.child.given_name, resp.child.birthday, resp.child.gender,
             resp.child.age_at_birth, resp.child.additional_information
         ]
 
@@ -134,8 +141,8 @@ class StudyResponsesMixin(ExperimenterLoginRequiredMixin, PermissionRequiredMixi
         """
         Returns header row for csv response data
         """
-        return ['response_id', 'response_sequence', 'response_conditions', 'response_exp_data', 'response_global_event_timings',
-            'response_completed', 'study_id', 'participant_id', 'participant_nickname', 'child_id', 'child_name',
+        return ['response_id', 'response_uuid', 'response_sequence', 'response_conditions', 'response_exp_data', 'response_global_event_timings',
+            'response_completed', 'study_id', 'study_uuid', 'participant_id', 'participant_uuid', 'participant_nickname', 'child_id', 'child_uuid', 'child_name',
             'child_birthday', 'child_gender', 'child_age_at_birth', 'child_additional_information']
 
     def post(self, request, *args, **kwargs):

--- a/exp/static/exp/css/app.css
+++ b/exp/static/exp/css/app.css
@@ -158,6 +158,12 @@ a:hover.view-responses-link {
     width:100%;
     height: 340px;
 }
+
+div.uuid-padding {
+    margin-top: -10px;
+    padding-top: 0px;
+}
+
 .view-response-block {
     display: block;
     width: 100%;

--- a/studies/templates/studies/study_detail.html
+++ b/studies/templates/studies/study_detail.html
@@ -95,6 +95,15 @@
                       </p>
                   </div>
               </div>
+              <div class="row">
+                  <div class="col-xs-12">
+                      <p>
+                         <span class="pr-md"><label class='pr-xs'> UUID: </label>
+                         {{ study.uuid }}
+                          <div class="small uuid-padding"><em>This is the study id that participants will see</em></div>
+                      </p>
+                  </div>
+              </div>
               <div class="row pb-lg">
                   <div class="col-xs-12 col-sm-3">
                       <p>

--- a/studies/templates/studies/study_participant_email.html
+++ b/studies/templates/studies/study_participant_email.html
@@ -87,22 +87,22 @@
                          <label>Recipients</label>
                          <select style="display:none" id="email_next_session" multiple class="email-list form-control">
                              {% for participant in email_next_session %}
-                                <option value="{{participant.id}}">{% if participant.nickname %} {{ participant.nickname }}{% else %} No nickname{% endif %}, Id: {{ participant.id }}</option>
+                                <option value="{{participant.id}}">{% if participant.nickname %} {{ participant.nickname }}{% else %} No nickname{% endif %}, Id: {{ participant.id }}, UUID: {{ participant.uuid }}</option>
                              {% endfor %}
                          </select>
                          <select style="display:none" id="email_new_studies" multiple class="email-list form-control">
                              {% for participant in email_new_studies %}
-                                <option value="{{participant.id}}">{% if participant.nickname %} {{ participant.nickname }}{% else %} No nickname{% endif %}, Id: {{ participant.id }}</option>
+                                <option value="{{participant.id}}">{% if participant.nickname %} {{ participant.nickname }}{% else %} No nickname{% endif %}, Id: {{ participant.id }}, UUID: {{ participant.uuid }}</option>
                              {% endfor %}
                          </select>
                          <select style="display:none" id="email_study_updates" multiple class="email-list form-control">
                              {% for participant in email_study_updates %}
-                                <option value="{{participant.id}}">{% if participant.nickname %} {{ participant.nickname }}{% else %} No nickname{% endif %}, Id: {{ participant.id }}</option>
+                                <option value="{{participant.id}}">{% if participant.nickname %} {{ participant.nickname }}{% else %} No nickname{% endif %}, Id: {{ participant.id }}, UUID: {{ participant.uuid }}</option>
                              {% endfor %}
                          </select>
                          <select style="display:none" id="email_response_questions" multiple class="email-list form-control">
                              {% for participant in email_response_questions %}
-                                <option value="{{participant.id}}">{% if participant.nickname %} {{ participant.nickname }}{% else %} No nickname{% endif %}, Id: {{ participant.id }}</option>
+                                <option value="{{participant.id}}">{% if participant.nickname %} {{ participant.nickname }}{% else %} No nickname{% endif %}, Id: {{ participant.id }}, UUID: {{ participant.uuid }}</option>
                              {% endfor %}
                          </select>
                          <p class="small">Hold down the Ctrl (windows) / Command (Mac) button to select multiple participants.</p>


### PR DESCRIPTION
# Purpose

Since researchers may be using the API to get data, the API surfaces only uuid's, not id's, while Experimenter surfaces id's. Show uuid's in places Experimenter-side, to link data.

# Changes
- Show study uuid on study detail page
- Show participant uuid on participant detail page
- Show participant uuids on study email pages
- Show response/participant/demographic snapshot, and children uuid's on study responses page
- Put ember app/django app installation info in read the docs