### PR TITLE
Feature/Pull in Relevant Docs from Old Experimenter

### DIFF
--- a/docs/source/frames.md
+++ b/docs/source/frames.md
@@ -1,0 +1,291 @@
+# Development: Custom Frames
+
+### Overview
+
+You may find you have a need for some experimental component is not included in Experimenter already. The goal of this
+section is to walk through extending the base functionality with your own code.
+
+We use the term 'frame' to describe the combination of JavaScript file and Handlebars HTML template that compose a
+**block** of an experiment.
+
+Experimenter is composed of three main modules:
+
+- **[lookit-api](https://github.com/CenterForOpenScience/lookit-api)**: The repo containing the Experimenter Django app.  The Lookit Django app is also in this repo.
+- **[ember-lookit-frameplayer](https://github.com/CenterForOpenScience/ember-lookit-frameplayer)**: A small Ember app that allows the API in lookit-api to talk to the exp-player
+- **[exp-player](https://github.com/CenterForOpenScience/exp-addons/tree/develop/exp-player)**: the built-in rendering engine for experiments built in Experimenter.  Contained in exp-addons.
+
+Generally, all 'frame' development will happen in the exp-player module. By nature of the way the ember-lookit-frameplayer
+repository is structured, this will mean making changes in the `ember-lookit-frameplayer/lib/exp-player` directory. These changes
+can be committed as part of the [exp-addons](https://github.com/CenterForOpenScience/exp-addons) git submodule
+(installed under `ember-lookit-frameplayer/lib`)
+
+### Getting Started
+
+One of the features of [Ember CLI](http://www.ember-cli.com/) is the ability to provide 'blueprints' for code. These
+are basically just templates of all of the basic boilerplate needed to create a certain piece of code. To begin
+developing your own frame:
+
+```bash
+cd ember-lookit-frameplayer/lib/exp-player
+ember generate exp-frame exp-<your_name>
+```
+
+Where `<your_name>` corresponds with the name of your choice.
+
+#### A Simple Example
+
+Let's walk though a basic example of 'exp-consent-form':
+
+```bash
+$ ember generate exp-frame
+installing exp-frame
+  create addon/components/exp-consent-form/component.js
+  create addon/components/exp-consent-form/template.hbs
+  create app/components/exp-consent-form.js
+```
+
+Notice this created three new files:
+- `addon/components/exp-consent-form/component.js`: the JS file for your 'frame'
+- `addon/components/exp-consent-form/template.hbs`: the Handlebars template for your 'frame'
+- `app/components/exp-consent-form.js`: a boilerplate file that exposes the new frame to the Ember app-
+  you will almost never need to modify this file.
+
+Let's take a deeper look at the `component.js` file:
+
+```javascript
+import ExpFrameBaseComponent from 'exp-player/components/exp-frame-base/component';
+import layout from './template';
+
+export default ExpFrameBaseComponent.extend({
+    type: 'exp-consent-form',
+    layout: layout,
+    meta: {
+        name: 'ExpConsentForm',
+        description: 'TODO: a description of this frame goes here.',
+        parameters: {
+            type: 'object',
+            properties: {
+                // define configurable parameters here
+            }
+        },
+        data: {
+            type: 'object',
+            properties: {
+                // define data to be sent to the server here
+            }
+        }
+    }
+});
+```
+
+The first section:
+
+```javascript
+import ExpFrameBaseComponent from 'exp-player/components/exp-frame-base';
+import layout from './template';
+
+export default ExpFrameBaseComponent.extend({
+    type: 'exp-consent-form',
+    layout: layout,
+...
+})
+```
+
+does several things:
+- imports the `ExpFrameBaseComponent`: this is the superclass that all 'frames' must extend
+- imports the `layout`: this tells Ember what template to use
+- extends `ExpFrameBaseComponent` and specifies `layout: layout`
+
+
+Next is the 'meta' section:
+
+```javascript
+    ...
+    meta: {
+        name: 'ExpConsentForm',
+        description: 'TODO: a description of this frame goes here.',
+        parameters: {
+            type: 'object',
+            properties: {
+                // define configurable parameters here
+            }
+        },
+        data: {
+            type: 'object',
+            properties: {
+                // define data to be sent to the server here
+            }
+        }
+    }
+...
+```
+
+which is comprised of:
+- name (optional): A human readable name for this 'frame'
+- description (optional): A human readable description for this 'frame'.
+- parameters: JSON Schema defining what configuration parameters this 'frame' accepts. When you define an experiment
+  that uses the frame, you will be able to specify configuration as part of the experiment definition. Any parameters in
+  this section will be automatically added as properties of the component, and directly accessible as `propertyName` from
+  templates or component logic.
+- data: JSON Schema defining what data this 'frame' outputs. Properties defined in this section represent properties of
+  the component that will get serialized and sent to the server as part of the payload for this experiment. You can get
+  these values by binding a value to an input box, for example, or you can define a custom computed property by that
+  name to have more control over how a value is sent to the server.  
+
+If you want to save the value of a configuration variables, you can reference it in both parameters *and* data.
+For example, this can be useful if your experiment randomly chooses some frame behavior when it loads for the user, and
+you want to save and track what value was chosen.
+
+#### Building out the Example
+
+Let's add some basic functionality to this 'frame'. First define some of the expected parameters:
+
+```javascript
+...
+    meta: {
+        ...,
+        parameters: {
+            type: 'object',
+            properties: {
+                title: {
+                    type: 'string',
+                    default: 'Notice of Consent'
+                },
+                body: {
+                    type: 'string',
+                    default: 'Do you consent to participate in this study?'
+                },
+                consentLabel: {
+                    type: 'string',
+                    default: 'I agree'
+                }
+            }
+        }
+    },
+...
+```
+
+And also the output data:
+
+```javascript
+...,
+    data: {
+        type: 'object',
+            properties: {
+                consentGranted: {
+                    type: 'boolean',
+                    default: false
+                }
+            }
+        }
+    }
+...
+```
+
+Since we indicated above that this 'frame' has a `consentGranted` property, let's add it to the 'frame' definition:
+
+```javascript
+export default ExpFrameBaseComponent.extend({
+    ...,
+    consentGranted: null,
+    meta: {
+    ...
+    }
+...
+```
+
+
+Next let's update `template.hbs` to look more like a consent form:
+
+```
+<div class="well">
+  <h1>{{ title }}</h1>
+  <hr>
+  <p> {{ body }}</p>
+  <hr >
+  <div class="input-group">
+    <span>
+      {{ consentLabel }}
+    </span>
+    {{input type="checkbox" checked=consentGranted}}
+  </div>
+</div>
+<div class="row exp-controls">
+  <!-- Next/Last/Previous controls. Modify as appropriate -->
+  <div class="btn-group">
+    <button class="btn btn-default" {{ action 'previous' }} > Previous </button>
+    <button class="btn btn-default pull-right" {{ action 'next' }} > Next </button>
+  </div>
+</div>
+```
+
+We don't want to let the participant navigate backwards or to continue unless they've checked the box, so let's change the footer to:
+
+```
+<div class="row exp-controls">
+  <div class="btn-group">
+    <button class="btn btn-default pull-right" disabled={{ consentNotGranted }} {{ action 'next' }} > Next </button>
+  </div>
+</div>
+```
+
+Notice the new property `consentNotGranted`; this will require a new computed field in our JS file:
+
+```javascript
+    meta: {
+        ...
+    },
+    consentNotGranted: Ember.computed.not('consentGranted')
+});
+```
+
+### Tips and tricks
+
+#### Tips for adding styles
+You will probably want to add custom styles to your frame, in order to control the size, placement, and color of
+elements. Experimenter uses a common web standard called [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS) for
+styles.*
+
+To add custom styles for a pre-existing component, you will need to create a file `<component-name.scss>` in the
+`addon/styles/components` directory of `exp-addons`. Then add a line to the top of `addon/styles/addon.scss`, telling
+it to use that style. For example,
+
+`@import "components/exp-video-physics";`
+
+
+Remember that anything in exp-addons is shared code. Below are a few good tips to help your addon stay isolated and
+distinct, so that it does not affect other projects.
+
+Here are a few tips for writing good styles:
+- Do not override global styles, or things that are part of another component. For example, `exp-video-physics` should
+not contain styles for `exp-player`, nor should it
+   - If you need to style a button specifically inside that component, either add a second style to the element, or
+     consider using nested [CSS selectors](https://developer.mozilla.org/en-US/docs/Learn/CSS/Introduction_to_CSS/Selectors).
+- Give all of the styles in your component a unique common name prefix, so that they don't inadvertently overlap with
+styles for other things. For example, instead of `some-video-widget`, consider a style name like `exp-myframe-video-widget`.
+
+\* You may notice that style files have a special extension `.scss`. That is because styles in experimenter are
+actually written in [SASS](http://sass-lang.com/). You can still write normal CSS just fine, but SASS provides
+additional syntax on top of that and can be helpful for power users who want complex things (like variables).
+
+#### When should I use actions vs functions?
+Actions should be used when you need to trigger a specific piece of functionality via user interaction: eg click a
+button to make something happen.
+
+Functions (or helper methods on a component/frame) should be used when the logic is shared, or not intended to be
+accessed directly via user interaction. It is usually most convenient for these methods to be defined as a part of the
+component, so that they can access data or properties of the component. Since functions can return a value, they are
+particularly helpful for things like sending data to a server, where you need to act on success or failure in order to
+display information to the user. (using promises, etc)
+
+Usually, you should use actions only for things that the user directly triggers. Actions and functions are not mutually
+exclusive! For example, an action called `save` might call an internal method called `this._save` to handle the
+behavior and message display consistently.
+
+If you find yourself using the same logic over and over, and it does not depend on properties of a particular
+ component, consider making it a [util](https://ember-cli.com/extending/#detailed-list-of-blueprints-and-their-use)!
+
+If you are building extremely complex nested components, you may also benefit from reading about closure actions. They
+can provide a way to act on success or failure of something, and are useful for :
+- [Ember closure actions have return values](https://alisdair.mcdiarmid.org/ember-closure-actions-have-return-values/)
+- [Ember.js Closure Actions Improve the Former Action Infrastructure](https://spin.atomicobject.com/2016/06/25/emberjs-closure-actions/)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,3 +22,6 @@ Contents:
    django-project-installation
    ember-app-installation
    local-frame-development
+   frames
+   mixins
+   random

--- a/docs/source/mixins.md
+++ b/docs/source/mixins.md
@@ -1,0 +1,23 @@
+# Development: Mixins of premade functionality
+
+Sometimes, you will wish to add a preset bundle of functionality to any arbitrary experiment frame. The Experimenter
+platform provides support for this via *mixins*. Below is a brief introduction to each of the common mixins;
+see sample usages throughout the exp-addons codebase. More documentation may be added in the future.
+
+
+## FullScreen
+This mixin is helpful when you want to show something (like a video) in fullscreen mode without distractions.
+You will need to specify the part of the page that will become full screen. By design, most browsers require that you
+interact with the page at least once before full screen mode can become active.
+
+## MediaReload
+If your component uses video or audio, you will probably want to use this mixin. It is very helpful if you ever expect
+to show two consecutive frames of the same type (eg two physics videos, or two things that play an audio clip). It
+automatically addresses a quirk of how ember renders the page; see [stackoverflow post](http://stackoverflow.com/a/18454389/1422268)
+for more information.
+
+## VideoPause
+Functionality related to pausing a video when the user presses the spacebar.
+
+## VideoRecord
+Functionality related to video capture, in conjunction with the HDFVR/ Wowza system (for which MIT has a license).

--- a/docs/source/random.md
+++ b/docs/source/random.md
@@ -28,7 +28,7 @@ Where:
 
 ### Making your own
 
-There is some template code included to help you get started. From within the `experimenter/lib/exp-player` directory,
+There is some template code included to help you get started. From within the `ember-lookit-frameplayer/lib/exp-player` directory,
 run:
 
 ```bash

--- a/docs/source/random.md
+++ b/docs/source/random.md
@@ -1,0 +1,156 @@
+# Development: Randomization
+
+Experimenter supports a special kind of frame called 'choice' that defers determining what sequence of frames a
+participant will see until the page loads. This allows for dynamic ordering of frame sequence in particular to
+support randomization of experimental conditions. The goal of this page is to walk through an example of
+implementing a custom 'randomizer'.
+
+### Overview of 'choice' structure
+
+Generally the structure for a 'choice' type frame takes the form:
+
+```json
+{
+    "kind": "choice",
+    "sampler": "random",
+    "options": [
+		"video1",
+		"video2"
+	]
+}
+```
+
+Where:
+- **sampler** indicates which 'randomizer' to use. This must correspond with the values defined in
+`lib/exp-player/addon/randomizers/index.js`
+- **options**: an array of options to sample from. These should correspond with values from the `frames` object defined
+ in the experiment structure (for more on this, see [the experiments docs](experiments.html))
+
+### Making your own
+
+There is some template code included to help you get started. From within the `experimenter/lib/exp-player` directory,
+run:
+
+```bash
+ember generate randomizer <name>
+```
+
+which will create a new file: `addon/randomizers/<name>.js`. Let's walk through an example called 'next. The 'next'
+randomizer simply picks the next frame in a series. (based on previous times that someone participated in an experiment)
+
+```bash
+$ ember generate randomizer next
+...
+installing randomizer
+  create addon/randomizers/next.js
+```
+
+Which looks like:
+```javascript
+/*
+ NOTE: you will need to manually add an entry for this file in addon/randomizers/index.js, e.g.:
+import
+import Next from './next';
+...
+{
+    ...
+    next: Next
+}
+ */
+var randomizer = function(/*frame, pastSessions, resolveFrame*/) {
+    // return [resolvedFrames, conditions]
+};
+export default randomizer;
+```
+
+The most important thing to note is that this module exports a single function. This function takes three arguments:
+	- `frame`: the JSON entry for the 'choice' frame in context
+	- `pastSessions`: an array of this participants past sessions of taking this experiment. See
+	  [the experiments docs](experiments.html) for more explanation of this data structure
+	- `resolveFrame`: a copy of the ExperimentParser's _resolveFrame method with the `this` context of the related
+	  ExperimentParser bound into the function.
+
+Additionally, this function should return a two-item array containing:
+	- a list of resolved frames
+	- the conditions used to determine that resolved list
+
+Let's walk through the implementation:
+
+```javascript
+var randomizer = function(frame, pastSessions, resolveFrame) {
+    pastSessions = pastSessions.filter(function(session) {
+        return session.get('conditions');
+    });
+    pastSessions.sort(function(a, b) {
+        return a.get('createdOn') > b.get('createdOn') ? -1: 1;
+    });
+	// ...etc
+};
+```
+
+First we make sure to filter the `pastSessions` to only the one with reported conditions, and make sure the sessions
+are sorted from most recent to least recent.
+
+```
+	...
+    var option = null;
+    if(pastSessions.length) {
+        var lastChoice = (pastSessions[0].get(`conditions.${frame.id}`) || frame.options[0]);
+        var offset = frame.options.indexOf(lastChoice) + 1;
+        option = frame.options.concat(frame.options).slice(offset)[0];
+    }
+    else {
+        option = frame.options[0];
+    }
+```
+
+Next we look at the conditions for this frame from the last session (`pastSessions[0].get(`conditions.${frame.id}`)`).
+ If that value is unspecified, we fall back to the first option in `frame.options`. We calculate the index of that
+ item in the available `frame.options`, and increment that index by one.
+
+This example allows the conditions to "wrap around", such that the "next" option after the last one in the series
+circles back to the first. To handle this we append the `options` array to itself, and slice into the resulting array to
+grab the "next" item.
+
+If there are not past sessions, then we just grab the first item from `options`.
+
+```
+    var [frames,] = resolveFrame(option);
+    return [frames, option];
+};
+
+export default randomizer;
+```
+
+Finally, we need to resolved the selected sequence using the `resolveFrame` argument. This function always returns a
+ two-item array containing:
+- an array of resolved frames
+- the conditions used to generate that array
+
+In this case we can ignore the second part of the return value, and only care about the returned `frames` array.
+
+The `export default randomizer` tells the module importer that this file exports a single item (`export default`),
+which in this case is the randomizer function (**note**: the name of this function is not important).
+
+Finally, lets make sure to add an entry to the index.js file in the same directory:
+```javascript
+import next from './next';
+
+export default {
+	...,
+    next: next
+};
+```
+
+This allows consuming code to easily import all of the randomizers at once and to index into the `randomizers` object
+dynamically, e.g. (from the `ExperimentParser`):
+
+```javascript
+import randomizers from 'exp-player/randomizers/index';
+// ...
+return randomizers[randomizer](
+	frame,
+	this.pastSessions,
+	this._resolveFrame.bind(this)
+);
+```

--- a/project/settings/defaults.py
+++ b/project/settings/defaults.py
@@ -224,7 +224,7 @@ SITE_NAME = os.environ.get('SITE_NAME', 'Lookit')
 EXPERIMENT_BASE_URL = os.environ.get('EXPERIMENT_BASE_URL', 'https://storage.googleapis.com/io-osf-lookit-staging2/experiments/')  # default to ember base url
 PREVIEW_EXPERIMENT_BASE_URL = os.environ.get('PREVIEW_EXPERIMENT_BASE_URL', 'https://storage.googleapis.com/io-osf-lookit-staging2/preview_experiments/')  # default to ember base url
 
-BASE_URL = os.environ.get('BASE_URL', 'http://localhost:8000')  # default to ember base url
+BASE_URL = os.environ.get('BASE_URL', 'http://localhost:8000/')  # default to ember base url
 OSF_URL = os.environ.get('OSF_URL', 'https://staging.osf.io/')  # default osf url used for oauth
 
 LOGIN_REDIRECT_URL = os.environ.get('LOGIN_REDIRECT_URL', 'http://localhost:8000/exp/')

--- a/studies/templates/emails/custom_email.html
+++ b/studies/templates/emails/custom_email.html
@@ -1,1 +1,3 @@
 <p> {{ custom_message }} </p>
+
+<a href="{{base_url}}account/email/"> Update your email preferences </a>

--- a/studies/templates/emails/custom_email.txt
+++ b/studies/templates/emails/custom_email.txt
@@ -1,1 +1,3 @@
 {{ custom_message }}
+
+Update your email preferences here: {{base_url}}account/email/


### PR DESCRIPTION
# Purpose

Experimenter has changed a lot, but the process for creating frames has not.  Pull over and modify the old frame docs from Experimenter v1 regarding creating frames, mixins in the exp-player and randomization in frames as they are still relevant to the new application.

- Also adds link to custom email where users can change email preferences 