### PR TITLE
Feature/Revert Changes to BASE_URL, URL Template Tag to build Email link

### DIFF
--- a/project/settings/defaults.py
+++ b/project/settings/defaults.py
@@ -224,7 +224,7 @@ SITE_NAME = os.environ.get('SITE_NAME', 'Lookit')
 EXPERIMENT_BASE_URL = os.environ.get('EXPERIMENT_BASE_URL', 'https://storage.googleapis.com/io-osf-lookit-staging2/experiments/')  # default to ember base url
 PREVIEW_EXPERIMENT_BASE_URL = os.environ.get('PREVIEW_EXPERIMENT_BASE_URL', 'https://storage.googleapis.com/io-osf-lookit-staging2/preview_experiments/')  # default to ember base url
 
-BASE_URL = os.environ.get('BASE_URL', 'http://localhost:8000/')  # default to ember base url
+BASE_URL = os.environ.get('BASE_URL', 'http://localhost:8000')  # default to ember base url
 OSF_URL = os.environ.get('OSF_URL', 'https://staging.osf.io/')  # default osf url used for oauth
 
 LOGIN_REDIRECT_URL = os.environ.get('LOGIN_REDIRECT_URL', 'http://localhost:8000/exp/')

--- a/studies/templates/emails/custom_email.html
+++ b/studies/templates/emails/custom_email.html
@@ -1,3 +1,3 @@
 <p> {{ custom_message }} </p>
 
-<a href="{{base_url}}account/email/"> Update your email preferences </a>
+<a href="{{base_url}}{% url 'web:email-preferences' %}"> Update your email preferences </a>

--- a/studies/templates/emails/custom_email.txt
+++ b/studies/templates/emails/custom_email.txt
@@ -1,3 +1,3 @@
 {{ custom_message }}
 
-Update your email preferences here: {{base_url}}account/email/
+Update your email preferences here: {{base_url}}{% url 'web:email-preferences' %}


### PR DESCRIPTION
# Purpose

In custom emails to participants, there should be an email link for participants to update their preferences. I had assumed that BASE_URL should have a trailing slash, but it does not on staging, and other emails are built assuming there is no trailing slash

# Changes
- Remove BASE_URL trailing slash locally to match staging
- Use URL template tag to build email preferences URL instead of manually constructing