### PR TITLE
[Fix] Parser-Renderer Overrides for Randomization [LEI-468]

### DIFF
--- a/api/parsers.py
+++ b/api/parsers.py
@@ -1,0 +1,10 @@
+from rest_framework_json_api import parsers
+from api import utils as api_utils
+
+class JSONAPIParser(parsers.JSONParser):
+    @staticmethod
+    def parse_attributes(data):
+        """
+        Overwrites rest_framework_json_api.parse_attributes method to only underscore top-level keys.
+        """
+        return api_utils.format_keys(data.get('attributes'), 'underscore') if data.get('attributes') else dict()

--- a/api/renderers.py
+++ b/api/renderers.py
@@ -13,6 +13,7 @@ from rest_framework.serializers import (BaseSerializer, ListSerializer,
 from rest_framework.settings import api_settings
 
 from rest_framework_json_api import utils
+from api import utils as api_utils
 
 
 class JSONAPIRenderer(renderers.JSONRenderer):
@@ -65,7 +66,7 @@ class JSONAPIRenderer(renderers.JSONRenderer):
                 field_name: resource.get(field_name)
             })
 
-        return utils.format_keys(data)
+        return api_utils.format_keys(data)
 
     @classmethod
     def extract_relationships(cls, fields, resource, resource_instance):
@@ -203,7 +204,7 @@ class JSONAPIRenderer(renderers.JSONRenderer):
                 })
                 continue
 
-        return utils.format_keys(data)
+        return api_utils.format_keys(data)
 
     @classmethod
     def extract_included(cls, fields, resource, resource_instance, included_resources):
@@ -313,7 +314,7 @@ class JSONAPIRenderer(renderers.JSONRenderer):
                         )
                     )
 
-        return utils.format_keys(included_data)
+        return api_utils.format_keys(included_data)
 
     @classmethod
     def extract_meta(cls, serializer, resource):
@@ -432,7 +433,7 @@ class JSONAPIRenderer(renderers.JSONRenderer):
                     json_resource_obj = self.build_json_resource_obj(fields, resource, resource_instance, resource_name)
                     meta = self.extract_meta(serializer, resource)
                     if meta:
-                        json_resource_obj.update({'meta': utils.format_keys(meta)})
+                        json_resource_obj.update({'meta': api_utils.format_keys(meta)})
                     json_api_data.append(json_resource_obj)
 
                     included = self.extract_included(fields, resource, resource_instance, included_resources)
@@ -444,7 +445,7 @@ class JSONAPIRenderer(renderers.JSONRenderer):
 
                 meta = self.extract_meta(serializer, serializer_data)
                 if meta:
-                    json_api_data.update({'meta': utils.format_keys(meta)})
+                    json_api_data.update({'meta': api_utils.format_keys(meta)})
 
                 included = self.extract_included(fields, serializer_data, resource_instance, included_resources)
                 if included:
@@ -478,7 +479,7 @@ class JSONAPIRenderer(renderers.JSONRenderer):
             render_data['included'] = sorted(unique_compound_documents, key=lambda item: (item['type'], item['id']))
 
         if json_api_meta:
-            render_data['meta'] = utils.format_keys(json_api_meta)
+            render_data['meta'] = api_utils.format_keys(json_api_meta)
 
         return super().render(
             render_data, accepted_media_type, renderer_context

--- a/api/tests/test_responses.py
+++ b/api/tests/test_responses.py
@@ -30,8 +30,8 @@ class ResponseTestCase(APITestCase):
         self.data = {
             "data": {
                 "attributes": {
-                  "global-event-timings": [],
-                  "exp-data": {},
+                  "global_event_timings": [],
+                  "exp_data": {},
                   "sequence": [],
                   "completed": False
                 },
@@ -55,8 +55,8 @@ class ResponseTestCase(APITestCase):
         self.patch_data = {
             "data": {
                 "attributes": {
-                  "global-event-timings": [],
-                  "exp-data": {"some":"data"},
+                  "global_event_timings": [],
+                  "exp_data": {"some":"data"},
                   "sequence": ['first_frame', 'second_frame'],
                   "completed": True
                 },
@@ -64,8 +64,6 @@ class ResponseTestCase(APITestCase):
                 "id": str(self.response.uuid)
             }
         }
-
-
 
     # Response List test
     def testGetResponseListUnauthenticated(self):
@@ -191,6 +189,115 @@ class ResponseTestCase(APITestCase):
         api_response = self.client.patch(self.response_detail_url, json.dumps(self.patch_data), content_type="application/vnd.api+json")
         self.assertEqual(api_response.status_code, status.HTTP_200_OK)
         self.assertEqual(api_response.data['sequence'], ['first_frame', 'second_frame'])
+
+    def testPatchResponseAttributesTopLevelKeysUnderscoredOnly(self):
+        self.client.force_authenticate(user=self.participant)
+
+        data = {
+        	"data": {
+        		"id": str(self.response.uuid),
+        		"attributes": {
+        			"conditions": {
+        				"8-pref-phys-videos": {
+        					"startType": 5,
+        					"showStay": 8,
+        					"whichObjects": [8, 5, 6, 8]
+        				}
+        			},
+        			"global_event_timings": [],
+        			"exp_data": {
+        				"0-0-video-config": {
+        					"eventTimings": [{
+        						"eventType": "nextFrame",
+        						"timestamp": "2017-10-31T20:09:47.479Z"
+        					}]
+        				},
+        				"1-1-video-consent": {
+        					"videoId": "e729321f-418f-4728-992c-9364623dbe9b_1-video-consent_bdebd15b-adc7-4377-b2f6-e9f3de70dd19",
+        					"eventTimings": [{
+        						"eventType": "hasCamAccess",
+        						"timestamp": "2017-10-31T20:09:48.096Z",
+        						"hasCamAccess": "True",
+        						"videoId": "e729321f-418f-4728-992c-9364623dbe9b_1-video-consent_bdebd15b-adc7-4377-b2f6-e9f3de70dd19",
+        						"streamTime": "None"
+        					}, {
+        						"eventType": "videoStreamConnection",
+        						"timestamp": "2017-10-31T20:09:50.534Z",
+        						"status": "NetConnection.Connect.Success",
+        						"videoId": "e729321f-418f-4728-992c-9364623dbe9b_1-video-consent_bdebd15b-adc7-4377-b2f6-e9f3de70dd19",
+        						"streamTime": "None"
+        					}, {
+        						"eventType": "stoppingCapture",
+        						"timestamp": "2017-10-31T20:09:53.051Z",
+        						"videoId": "e729321f-418f-4728-992c-9364623dbe9b_1-video-consent_bdebd15b-adc7-4377-b2f6-e9f3de70dd19",
+        						"streamTime": 2.459000000000003
+        					}, {
+        						"eventType": "nextFrame",
+        						"timestamp": "2017-10-31T20:09:53.651Z",
+        						"videoId": "e729321f-418f-4728-992c-9364623dbe9b_1-video-consent_bdebd15b-adc7-4377-b2f6-e9f3de70dd19",
+        						"streamTime": "None"
+        					}]
+        				},
+        				"2-2-instructions": {
+        					"confirmationCode": "6YdLL",
+        					"eventTimings": [{
+        						"eventType": "nextFrame",
+        						"timestamp": "2017-10-31T20:09:56.472Z"
+        					}]
+        				},
+        				"5-5-mood-survey": {
+        					"rested": "1",
+        					"healthy": "1",
+        					"childHappy": "1",
+        					"active": "1",
+        					"energetic": "1",
+        					"ontopofstuff": "1",
+        					"parentHappy": "1",
+        					"napWakeUp": "11:00",
+        					"usualNapSchedule": "no",
+        					"lastEat": "6:00",
+        					"doingBefore": "s",
+        					"eventTimings": [{
+        						"eventType": "nextFrame",
+        						"timestamp": "2017-10-31T20:10:17.269Z"
+        					}]
+        				}
+        			},
+        			"sequence": ["0-0-video-config", "1-1-video-consent", "2-2-instructions", "5-5-mood-survey"],
+        			"completed": "False"
+        		},
+        		"type": "responses"
+        	}
+        }
+
+        api_response = self.client.patch(self.response_detail_url, json.dumps(data), content_type="application/vnd.api+json")
+        self.assertEqual(api_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(api_response.data['sequence'],  ["0-0-video-config", "1-1-video-consent", "2-2-instructions", "5-5-mood-survey"])
+        self.assertEqual(api_response.data['exp_data']['0-0-video-config'],  {
+            "eventTimings": [{
+                "eventType": "nextFrame",
+                "timestamp": "2017-10-31T20:09:47.479Z"
+            }]
+        })
+        self.assertEqual(api_response.data['exp_data']['5-5-mood-survey'],
+            {
+                "rested": "1",
+                "healthy": "1",
+                "childHappy": "1",
+                "active": "1",
+                "energetic": "1",
+                "ontopofstuff": "1",
+                "parentHappy": "1",
+                "napWakeUp": "11:00",
+                "usualNapSchedule": "no",
+                "lastEat": "6:00",
+                "doingBefore": "s",
+                "eventTimings": [{
+                    "eventType": "nextFrame",
+                    "timestamp": "2017-10-31T20:10:17.269Z"
+                }]
+            }
+        )
 
     # Delete responses
     def testDeleteResponse(self):

--- a/api/tests/test_responses.py
+++ b/api/tests/test_responses.py
@@ -71,6 +71,18 @@ class ResponseTestCase(APITestCase):
         api_response = self.client.get(self.url, content_type="application/vnd.api+json")
         self.assertEqual(api_response.status_code, status.HTTP_401_UNAUTHORIZED)
 
+    def testGetResponseOrderingReverseDateModified(self):
+        assign_perm('studies.can_view_study_responses', self.researcher, self.study)
+        self.client.force_authenticate(user=self.researcher)
+        self.response2 = G(Response, child=self.child, study=self.study, completed=False)
+        self.response3 = G(Response, child=self.child, study=self.study, completed=False)
+        api_response = self.client.get(self.url, content_type="application/vnd.api+json")
+        self.assertEqual(api_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(api_response.data['links']['meta']['count'], 3)
+        self.assertIn(str(self.response3.uuid), api_response.data['results'][0]['url'])
+        self.assertIn(str(self.response2.uuid), api_response.data['results'][1]['url'])
+        self.assertIn(str(self.response.uuid), api_response.data['results'][2]['url'])
+
     def testGetResponsesListByOwnChildren(self):
         # Participant can view their own responses
         self.client.force_authenticate(user=self.participant)

--- a/api/utils.py
+++ b/api/utils.py
@@ -1,0 +1,42 @@
+from collections import OrderedDict
+
+import inflection
+from rest_framework.settings import api_settings
+
+def format_keys(obj, format_type=None):
+    """
+    Overwrites rest_framework_json_api/utils.py
+
+    Does not recursively format dictionary keys. Only top level keys are formatted.
+
+    :format_type: Either 'dasherize', 'camelize' or 'underscore'
+    """
+    if format_type is None:
+        format_type = getattr(api_settings, 'JSON_API_FORMAT_KEYS', False)
+
+    if format_type in ('dasherize', 'camelize', 'underscore', 'capitalize'):
+
+        if isinstance(obj, dict):
+            formatted = OrderedDict()
+            for key, value in obj.items():
+                if format_type == 'dasherize':
+                    # inflection can't dasherize camelCase
+                    key = inflection.underscore(key)
+                    formatted[inflection.dasherize(key)] \
+                        = value
+                elif format_type == 'camelize':
+                    formatted[inflection.camelize(key, False)] \
+                        = value
+                elif format_type == 'capitalize':
+                    formatted[inflection.camelize(key)] \
+                        = value
+                elif format_type == 'underscore':
+                    formatted[inflection.underscore(key)] \
+                        = value
+            return formatted
+        if isinstance(obj, list):
+            return [format_keys(item, format_type) for item in obj]
+        else:
+            return obj
+    else:
+        return obj

--- a/api/views.py
+++ b/api/views.py
@@ -146,7 +146,7 @@ class StudyViewSet(FilterByUrlKwargsMixin, views.ModelViewSet):
         if 'List' in self.get_view_name():
             qs = qs.filter(public=True)
 
-        return (qs | get_objects_for_user(self.request.user, 'studies.can_edit_study')).distinct()
+        return (qs | get_objects_for_user(self.request.user, 'studies.can_edit_study')).distinct().order_by('-date_modified')
 
 class ResponseFilter(filters.FilterSet):
     child = filters.UUIDFilter(name='child__uuid')
@@ -195,13 +195,13 @@ class ResponseViewSet(FilterByUrlKwargsMixin, views.ModelViewSet):
             study_uuid = self.kwargs['study_uuid']
             queryset = Response.objects.filter(study__uuid=study_uuid)
             if self.request.user.has_perm('studies.can_view_study_responses', get_object_or_404(Study, uuid=study_uuid)):
-                return queryset
+                return queryset.order_by('-date_modified')
             else:
-                return queryset.filter(child__id__in=children_ids)
+                return queryset.filter(child__id__in=children_ids).order_by('-date_modified')
 
         studies = get_objects_for_user(self.request.user, 'studies.can_view_study_responses')
         study_ids = studies.values_list('id', flat=True)
-        return Response.objects.filter(Q(study__id__in=study_ids) | Q(child__id__in=children_ids)).distinct()
+        return Response.objects.filter(Q(study__id__in=study_ids) | Q(child__id__in=children_ids)).distinct().order_by('-date_modified')
 
 
 class FeedbackViewSet(FilterByUrlKwargsMixin, views.ModelViewSet):

--- a/docs/source/api-documentation.rst
+++ b/docs/source/api-documentation.rst
@@ -13,7 +13,81 @@ Most endpoints in this API are just meant for retrieving data. Typically, you ca
 ---------------
 API Formatting
 ---------------
-This API generally conforms to the `JSON-API 1.0 spec <http://jsonapi.org/format/1.0/>`_ .
+This API generally conforms to the `JSON-API 1.0 spec <http://jsonapi.org/format/1.0/>`_ .  Top-level keys are underscored, while nested key formatting will be the casing that is stored in the db. For example, in the study response below, top-level attributes like `exp_data` and `global_event_timings` are underscored.  However, nested keys like `5-5-mood-survey` and `napWakeUp` retain the casing given to them by the `exp-player`.
+
+.. code-block:: json
+
+    {
+        "type": "responses",
+        "id": "bdebd15b-adc7-4377-b2f6-e9f3de70dd19",
+        "attributes": {
+            "conditions": {
+                "8-pref-phys-videos": {
+                    "showStay": 8,
+                    "startType": 5,
+                    "whichObjects": [
+                        8,
+                        5,
+                        6,
+                        8
+                    ]
+                }
+            },
+            "global_event_timings": [
+                {
+                    "exitType": "browserNavigationAttempt",
+                    "eventType": "exitEarly",
+                    "timestamp": "2017-10-31T20:30:38.514Z",
+                    "lastPageSeen": 6
+                }
+            ],
+            "exp_data": {
+                "5-5-mood-survey": {
+                    "active": "1",
+                    "rested": "1",
+                    "healthy": "1",
+                    "lastEat": "6:00",
+                    "energetic": "1",
+                    "napWakeUp": "11:00",
+                    "childHappy": "1",
+                    "doingBefore": "s",
+                    "parentHappy": "1",
+                    "eventTimings": [
+                        {
+                            "eventType": "nextFrame",
+                            "timestamp": "2017-10-31T20:10:17.269Z"
+                        }
+                    ],
+                    "ontopofstuff": "1",
+                    "usualNapSchedule": "no"
+                }
+            },
+            "sequence": [
+                "5-5-mood-survey"
+            ],
+            "completed": false
+        },
+        "relationships": {
+            "child": {
+                "links": {
+                    "related": "http://localhost:8000/api/v1/children/da27faf2-c3d2-4701-b3bb-dd865f89c1a1/"
+                }
+            },
+            "study": {
+                "links": {
+                    "related": "http://localhost:8000/api/v1/studies/e729321f-418f-4728-992c-9364623dbe9b/"
+                }
+            },
+            "demographic_snapshot": {
+                "links": {
+                    "related": "http://localhost:8000/api/v1/demographics/341ea7c7-f657-4ab2-a530-21ac293e7d6f/"
+                }
+            }
+        },
+        "links": {
+            "self": "http://localhost:8000/api/v1/responses/bdebd15b-adc7-4377-b2f6-e9f3de70dd19/"
+        }
+    }
 
 ------------
 Content-Type
@@ -587,6 +661,8 @@ GET /api/v1/responses/
 
 Permissions: Must be authenticated.  You can only view responses to studies you have permission to view. Additionally, you can view your own responses through the API.
 
+Sort Order: By default, responses are sorted reverse date_modified, meaning the most recently modified responses appear first.
+
 *Sample Response:*
 
 .. code-block:: json
@@ -769,6 +845,8 @@ Viewing the list of studies
 GET /api/v1/studies/
 
 Permissions: Must be authenticated. You can view studies that are active/public as well as studies you have permission to edit.
+
+Sort Order: By default, studies are sorted reverse date_modified, meaning the most recently modified studies appear first.
 
 *Sample Response:*
 

--- a/project/settings/defaults.py
+++ b/project/settings/defaults.py
@@ -185,7 +185,7 @@ REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS':
         'api.pagination.PageNumberPagination',
     'DEFAULT_PARSER_CLASSES': (
-        'rest_framework_json_api.parsers.JSONParser',
+        'api.parsers.JSONAPIParser',
         'rest_framework.parsers.FormParser',
         'rest_framework.parsers.MultiPartParser'
     ),


### PR DESCRIPTION
# Ticket 
https://openscience.atlassian.net/browse/LEI-468

# Purpose

The pref-phys randomizer isn't using information about past sessions from the same child; it's just choosing random conditions each time. The tests here outline what should be happening; the problem is presumably that data from previous sessions isn't being found: https://github.com/CenterForOpenScience/exp-addons/blob/develop/exp-player/tests/unit/randomizers/pref-phys-test.js

# Changes
Issues was with casing.  Even though the pref-phys randomizer had all the pastSessions, the casing of nested keys were different than what the randomizer expected.  Top level keys should be underscored, but nested keys below top-level should be left as-is.  However the exp-player or the various frames format the nested keys, is how the casing should remain. 

To fix:
- new utils/format_keys method was created to override original behavior in 3rd party rest-framework-json-api package.  Instead of recursively modifying the format of all keys, just modify the top-level keys
- Use this new format_keys method in the JSONAPIRenderer
- Create a new JSONAPIParser that parses keys using the new format_keys method
- Default order API responses (and studies) so that the most recently modified studies are returned first
- Add tests for casing and default ordering of responses
- Updating documentation for API casing and default ordering of studies/responses