### PR TITLE
Fix/Firefox Video Recording [LEI-467]

### DIFF
--- a/docs/source/local-frame-development.md
+++ b/docs/source/local-frame-development.md
@@ -44,13 +44,13 @@ as a token for accessing the API.  Leave the django server running and switch to
     If you make changes to the frames, you should see notifications that files have changed in the console where your ember server is running:
     `file changed components/exp-video-config/template.hbs`
 
-3. Add your token to the header. This will allow your Ember app to talk to your local API. In the ember-frame-player directory, open the application adapter directory at `ember-lookit-frameplayer/app/adapters/application.js.` Add an "Authorization" key beneath the X-CSRFTOKEN line. Save the file.
+3. Add your token to the header. This will allow your Ember app to talk to your local API. In the ember-frame-player directory, open the application adapter directory at `ember-lookit-frameplayer/app/adapters/application.js.` Add an "Authorization" key beneath the X-CSRFTOKEN line. The word 'Token' must be included. Save the file.
     ```js
     headers: Ember.computed(function() {
             // Add cookie to http header
             return {
                 'X-CSRFTOKEN': Ember.get(document.cookie.match(/csrftoken\=([^;]*)/), '1'),
-                'Authorization': 'Token add-your-token-here'
+                'Authorization': 'Token <add-your-token-here>.'
             };
         }).volatile(),
     ```

--- a/web/views.py
+++ b/web/views.py
@@ -334,9 +334,13 @@ class ExperimentAssetsProxyView(ProxyView, LoginRequiredMixin):
             self.upstream = settings.PREVIEW_EXPERIMENT_BASE_URL
         uuid = kwargs.pop('uuid', None)
         filename = kwargs.pop('filename', None)
+        # if it's one of the hdfv files
         if filename:
-            # if it's one of the hdfv files
-            study_uuid = referer.split('/')[-3]
+            if referer.endswith('/'):
+                study_uuid = referer.split('/')[-3]
+            else:
+                # For firefox
+                study_uuid = referer.split('/')[-2]
             path = f"{study_uuid}/{filename}"
             return super().dispatch(request, path, *args, **kwargs)
         # if it's just regular assets remove the child_id from the path


### PR DESCRIPTION
# Ticket
https://openscience.atlassian.net/browse/LEI-467

# Purpose 
From Kim: Video recording isn't working for me or collaborators in Firefox on the staging site (tested on staging-lookit.cos.io), although it does work on lookit.mit.edu and on Chrome. We see a message "Could not load settings" in the Flash player. 
<img width="1084" alt="screen shot 2017-11-15 at 2 05 47 pm" src="https://user-images.githubusercontent.com/9755598/32857674-3e252556-ca0e-11e7-8248-3ca70d68feec.png">

# Theory
For loading some needed video recording assets, the Chrome referer is this format: `/studies/study_id/child_id/`, but the Firefox referer looks something like `/studies/<study_id>/VideoRecorder.swf` Thanks @icereval for discovering this.

# Change
The referrer is split into a list based on the `/` character.  If referer ends in a '/', access study id three spots from end. Otherwise study id is two spots from end.

(While I'm here add Token clarification to docs).