### PR TITLE
Migration changes

### DIFF
--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -5,11 +5,11 @@ from accounts.models import DemographicData, Organization, Child, User
 
 
 class ChildAdmin(GuardedModelAdmin):
-    list_display = ('id', 'uuid', 'given_name', 'user')
+    list_display = ('id', 'uuid', 'given_name', 'birthday', 'user')
 
 
 class UserAdmin(GuardedModelAdmin):
-    list_display = ('id', 'uuid', 'nickname', 'given_name', 'family_name', 'is_staff', 'is_researcher')
+    list_display = ('id', 'uuid', 'nickname', 'given_name', 'family_name', 'is_staff', 'is_researcher', 'date_created', 'last_login')
 
 
 class OrganizationAdmin(GuardedModelAdmin):
@@ -17,7 +17,7 @@ class OrganizationAdmin(GuardedModelAdmin):
 
 
 class DemographicDataAdmin(GuardedModelAdmin):
-    pass
+    list_display = ('id', 'uuid', 'date_created', 'user')
 
 
 admin.site.register(User, UserAdmin)

--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -5,11 +5,11 @@ from accounts.models import DemographicData, Organization, Child, User
 
 
 class ChildAdmin(GuardedModelAdmin):
-    pass
+    list_display = ('id', 'uuid', 'given_name', 'user')
 
 
 class UserAdmin(GuardedModelAdmin):
-    pass
+    list_display = ('id', 'uuid', 'nickname', 'given_name', 'family_name', 'is_staff', 'is_researcher')
 
 
 class OrganizationAdmin(GuardedModelAdmin):

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -224,7 +224,7 @@ class User(AbstractBaseUser, PermissionsMixin, GuardianUserMixin):
         return f'{self.given_name} {self.middle_name} {self.family_name}'
 
     def __str__(self):
-        return f'<User: {self.uuid}>'
+        return f'<User: ID {self.id}, {self.uuid}>'
 
     objects = UserManager()
 
@@ -465,7 +465,7 @@ class DemographicData(models.Model):
         lookup_field = 'uuid'
 
     def __str__(self):
-        return f'<DemographicData: {self.user.get_short_name()} @ {self.created_at:%c}>'
+        return f'<DemographicData: {self.user.nickname} @ {self.created_at:%c}>'
 
     def to_display(self):
         return dict(

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -243,7 +243,7 @@ class User(AbstractBaseUser, PermissionsMixin, GuardianUserMixin):
             ('can_read_all_user_data', _('Can Read All User Data')),
             ('can_read_usernames', _('Can Read User Usernames')),
         )
-        ordering = ['username']
+        ordering = ['id']
 
 
 class Child(models.Model):

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -224,7 +224,7 @@ class User(AbstractBaseUser, PermissionsMixin, GuardianUserMixin):
         return f'{self.given_name} {self.middle_name} {self.family_name}'
 
     def __str__(self):
-        return f'<User: {self.get_short_name()}>'
+        return f'<User: {self.uuid}>'
 
     objects = UserManager()
 
@@ -291,7 +291,7 @@ class Child(models.Model):
     )
 
     def __str__(self):
-        return f'<Child: {self.given_name}, child of {self.user.get_short_name()}>'
+        return f'<Child: {self.given_name}, child of {self.user.nickname}>'
 
     class Meta:
         ordering = ['-birthday']

--- a/accounts/scripts/import_jamdb_participants.py
+++ b/accounts/scripts/import_jamdb_participants.py
@@ -238,12 +238,12 @@ def create_participant(participant, apps):
     # - Don't seem to be many email preferences in db?
     attributes = participant.get('attributes')
     user_model = apps.get_model("accounts", "User")
+    old_name = get_simple_field(attributes.get('name'))
     user = user_model.objects.create(
         username=attributes.get('email'),
         password='bcrypt$' + attributes.get('password'),
         former_lookit_id=participant.get('id'),
-        given_name=get_simple_field(attributes.get('name')),
-        nickname=get_simple_field(participant.get('id').split('.')[-1]),
+        nickname=(old_name if old_name else get_simple_field(participant.get('id').split('.')[-1])),
         is_active=True,
         is_staff=False,
         is_researcher=False,


### PR DESCRIPTION
Included here are some suggested minor changes before migration - here for concreteness, merge only if useful to you.

1. Transfer old 'name' field to new nickname field when available

2. Show some useful fields in the admin interface so we can find researchers / participants more easily if manual changes are needed (e.g. giving permissions). I'm not attached to the specific format here - e.g., if it'd be better to primarily display user uuids and order the user list by uuid, that's fine. (I just don't want it ordered by (hidden) username when I need to use a dropdown menu to select among thousands of options.) Or if you'd rather not include/allow sorting by certain fields in the admin interface.